### PR TITLE
chore: rename branch in documentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,26 +28,26 @@ Before we're able to merge your code into the OpenCloud app for Android, please,
      - ```improvement/improvement_name``` → make even better an existing feature
      - ```technical/technical_description```  → code review, DB... technical stuff improved
 
-	Please, use the mentioned prefixes because CI system is ready to match with them. Be sure your feature, fix, improvement or technical branches are updated with latest changes in official `android/master`, it will give us a better chance to test your code before merging it with stable code.
-* Once you are done with your code, start a pull request to merge your contribution into official `android/master`.
+	Please, use the mentioned prefixes because CI system is ready to match with them. Be sure your feature, fix, improvement or technical branches are updated with latest changes in official `android/main`, it will give us a better chance to test your code before merging it with stable code.
+* Once you are done with your code, start a pull request to merge your contribution into official `android/main`.
 * Keep on using pull requests for your next contributions although you own write permissions.
 * Important to mention that ÒpenCloud Android team uses OneFlow as branching model. It's something as useful as easy:
 
-  * `master` will stay as main branch. Everything will work around it.
-  * Feature branch: new branch created from `master`. Once it is finished and DoD accomplished, rebased and merged into `master`.
-  * Release branch: will work as any feature branch. Before rebasing and merging into `master`, release tag must be signed.
-  * Hotfix branch: created from latest tag. Once it is finished, tag must be signed. Then, rebased and merged into `master`.
+  * `main` will stay as main branch. Everything will work around it.
+  * Feature branch: new branch created from `main`. Once it is finished and DoD accomplished, rebased and merged into `main`.
+  * Release branch: will work as any feature branch. Before rebasing and merging into `main`, release tag must be signed.
+  * Hotfix branch: created from latest tag. Once it is finished, tag must be signed. Then, rebased and merged into `main`.
   * The way to get an specific version is browsing through the tags.
 
 	Interesting [link](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) about this.
 
-### 1. Fork and download android/master repository:
+### 1. Fork and download android/main repository:
 
-* Please follow [SETUP.md](https://github.com/opencloud-eu/android/blob/master/SETUP.md) to setup OpenCloud Android app work environment.
+* Please follow [SETUP.md](https://github.com/opencloud-eu/android/blob/main/SETUP.md) to setup OpenCloud Android app work environment.
 
 ### 2. Create pull request:
 
-* Create new feature, fix, improvement or technical enhancement branch from your master branch: ```git checkout -b feature/feature_name```
+* Create new feature, fix, improvement or technical enhancement branch from your main branch: ```git checkout -b feature/feature_name```
 * Register your changes: `git add filename`
 * Commit your changes locally. Please, if posible use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) to add descriptive messages to the commits. Take the simplest approach:
 	- Feature commits: `feat: brief description of the changes performed`
@@ -60,17 +60,17 @@ Before we're able to merge your code into the OpenCloud app for Android, please,
 * Browse to https://github.com/YOURGITHUBNAME/android/pulls and issue pull request
 * Enter description and send pull request.
 
-### 3. Update your contribution branch with master changes:
+### 3. Update your contribution branch with main changes:
 
 It is possible you see the next message from time to time.
 
 <img src="docs_resources/out_of_date_branch.png" />
 
-To fix this and make sure your contribution branch is updated with official android/master, you need to perform the next steps:
-* Checkout your master branch: ```git checkout master```
-* Get and apply official android/master branch changes in your master branch: ```git fetch upstream``` + ```git rebase upstream/master```. Now you have your master branch updated with official master branch changes.
+To fix this and make sure your contribution branch is updated with official android/main, you need to perform the next steps:
+* Checkout your main branch: ```git checkout main```
+* Get and apply official android/main branch changes in your main branch: ```git fetch upstream``` + ```git rebase upstream/main```. Now you have your main branch updated with official main branch changes.
 * Checkout your contribution branch: ```git checkout feature/feature_name```
-* Rebase contribution branch with master to put your contribution commits after the last commit of master branch, ensuring a clean commits history: ```git rebase master```. If there's some conflicts, solve it by using rebase in different steps.
+* Rebase contribution branch with main to put your contribution commits after the last commit of main branch, ensuring a clean commits history: ```git rebase main```. If there's some conflicts, solve it by using rebase in different steps.
 * Push branch to server: ```git push -f origin feature/feature_name```. At this point, the message ```This branch is out-of-date with the base branch``` should disappear.
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 **Build status:** <br>
 
-|master (Unit tests and data instrumented tests)| ![](https://app.bitrise.io/app/FIXME/status.svg?token=FIXME&branch=master)|
-| :----- | :------ |
-|**master (UI tests)**| ![](https://app.bitrise.io/app/FIXME/status.svg?token=FIXME/&branch=master)|
+| main (Unit tests and data instrumented tests) | ![](https://app.bitrise.io/app/FIXME/status.svg?token=FIXME&branch=main)|
+|:----------------------------------------------| :------ |
+| **main (UI tests)**                         | ![](https://app.bitrise.io/app/FIXME/status.svg?token=FIXME/&branch=main)|
 
 
-**Start contributing:** Make sure you read [SETUP.md](https://github.com/opencloud-eu/android/blob/master/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the master branch.
+**Start contributing:** Make sure you read [SETUP.md](https://github.com/opencloud-eu/android/blob/main/SETUP.md) when you start working on this project. Basically: Fork this repository and contribute back using pull requests to the main branch.
 Easy starting points are also reviewing [pull requests](https://github.com/opencloud-eu/android/pulls) and working on [contributions are welcome](https://github.com/opencloud-eu/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Contributions+are+welcome%22).
 
-**License:** [LICENSE.txt](https://github.com/opencloud-eu/android/blob/master/LICENSE.txt)
+**License:** [LICENSE.txt](https://github.com/opencloud-eu/android/blob/main/LICENSE.txt)
 
 ## Join testing!
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -36,9 +36,9 @@ Next steps will assume you have a Github account and that you will get the code 
 * Open a terminal and go on with the next steps in it.
 * Clone your forked repository: ```git clone https://github.com/YOURGITHUBNAME/android.git```.
 * Move to the project folder with ```cd android```.
-* Fetch and apply any changes from your remote branch 'master': ```git fetch``` + ```git rebase```
+* Fetch and apply any changes from your remote branch 'main': ```git fetch``` + ```git rebase```
 * Make official OpenCloud repo known as upstream: ```git remote add upstream https://github.com/opencloud-eu/android.git```
-* Make sure to get and apply the latest changes from official android/master branch: ```git fetch upstream``` + ```git rebase upstream/master```
+* Make sure to get and apply the latest changes from official android/main branch: ```git fetch upstream``` + ```git rebase upstream/main```
 
 At this point you can continue using different tools to build the project. Section 2 and 3 describe the existing alternatives.
 
@@ -69,7 +69,7 @@ The first time the Gradle wrapper is called, the correct Gradle version will be 
 The generated APK file is saved in android/build/outputs/apk as android-debug.apk
 
 
-[0]: https://github.com/opencloud-eu/android/blob/master/CONTRIBUTING.md
+[0]: https://github.com/opencloud-eu/android/blob/main/CONTRIBUTING.md
 [1]: https://git-scm.com/
 [2]: https://git-scm.com/downloads
 [3]: https://developer.android.com/sdk/index.html


### PR DESCRIPTION
In a lot of places the `master` branch was still used, but I believe the `main` branch is what should be used