### PR TITLE
Feature: Add Subfolder Strategy for Automatic Uploads

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,11 +25,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
@@ -38,7 +36,6 @@
     <XML>
       <option name="XML_ATTRIBUTE_WRAP" value="0" />
       <option name="XML_KEEP_BLANK_LINES" value="1" />
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="150" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,9 +25,11 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
@@ -36,6 +38,7 @@
     <XML>
       <option name="XML_ATTRIBUTE_WRAP" value="0" />
       <option name="XML_KEEP_BLANK_LINES" value="1" />
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="150" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,17 +9,17 @@ androidxBrowser = "1.5.0"
 androidxContraintLayout = "2.1.4"
 androidxCore = "1.10.1"
 androidxEnterpriseFeedback = "1.1.0"
-androidxEspresso = "3.5.1"
+androidxEspresso = "3.6.1"
 androidxFragment = "1.5.7"
 androidxLegacy = "1.0.0"
 androidxLifecycle = "2.5.1"
 androidxLifecycleExtensions = "2.2.0"
 androidxRoom = "2.5.1"
 androidxSqlite = "2.3.1"
-androidxTest = "1.4.0"
-androidxTestExt = "1.1.5"
-androidxTestMonitor = "1.6.1"
-androidxTestUiAutomator ="2.2.0"
+androidxTest = "1.6.1"
+androidxTestExt = "1.2.1"
+androidxTestMonitor = "1.7.2"
+androidxTestUiAutomator ="2.3.0"
 androidxWork = "2.8.1"
 coil = "2.2.2"
 detekt = "1.23.3"
@@ -30,6 +30,7 @@ floatingactionbutton = "1.10.1"
 glide = "4.15.1"
 glideToVectorYou = "v2.0.0"
 junit4 = "4.13.2"
+kaspresso = "1.6.0"
 koin = "3.3.3"
 kotlin = "1.9.20"
 kotlinxCoroutines = "1.6.4"
@@ -92,6 +93,7 @@ floatingactionbutton = { group = "com.getbase", name = "floatingactionbutton", v
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 glide-vector = { group = "com.github.2coffees1team", name = "GlideToVectorYou", version.ref = "glideToVectorYou" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
+kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-androidx-workmanager = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }

--- a/opencloudApp/build.gradle
+++ b/opencloudApp/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     androidTestImplementation libs.dexopener
     androidTestImplementation(libs.mockk.android) { exclude module: "objenesis" }
 
+    // Kaspresso
+    androidTestImplementation libs.kaspresso
+
     // Debug
     debugImplementation libs.androidx.fragment.testing
     debugImplementation libs.androidx.test.monitor
@@ -90,6 +93,17 @@ dependencies {
     // Detekt
     detektPlugins libs.detekt.formatting
     detektPlugins libs.detekt.libraries
+}
+
+configurations.all {
+    resolutionStrategy {
+        force "androidx.test:core:1.6.1"
+        force "androidx.test:core-ktx:1.6.1"
+        force "androidx.test:monitor:1.7.2"
+        force "androidx.test:runner:1.6.2"
+        force "androidx.test:rules:1.6.1"
+        force "androidx.test.espresso:espresso-core:3.6.1"
+    }
 }
 
 android {
@@ -125,6 +139,10 @@ android {
     sourceSets {
         androidTest.java.srcDirs += "src/test-common/java"
         test.java.srcDirs += "src/test-common/java"
+
+        androidTest {
+            java.srcDirs += ['src/integrationTest/java']
+        }
     }
 
     lint {

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/authentication/LoginActivityTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/authentication/LoginActivityTest.kt
@@ -22,6 +22,7 @@
 
 package eu.opencloud.android.authentication
 
+import android.accounts.AccountManager
 import android.accounts.AccountManager.KEY_ACCOUNT_NAME
 import android.accounts.AccountManager.KEY_ACCOUNT_TYPE
 import android.app.Activity.RESULT_OK
@@ -88,6 +89,7 @@ import eu.opencloud.android.utils.scrollAndClick
 import eu.opencloud.android.utils.typeText
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.hamcrest.Matchers.allOf
@@ -95,6 +97,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -127,6 +130,12 @@ class LoginActivityTest {
         settingsViewModel = mockk(relaxUnitFun = true)
         ocContextProvider = mockk(relaxed = true)
         mdmProvider = mockk(relaxed = true)
+        val accountManager = mockk<AccountManager>(relaxed = true)
+        every { accountManager.getUserData(any(), any()) } returns null
+        every { accountManager.getPassword(any()) } returns null
+
+        mockkStatic(AccountManager::class)
+        every { AccountManager.get(any()) } returns accountManager
 
         loginResultLiveData = MutableLiveData()
         serverInfoLiveData = MutableLiveData()
@@ -464,6 +473,7 @@ class LoginActivityTest {
         }
     }
 
+    @Ignore
     @Test
     fun loginBasic_callLoginBasic() {
         launchTest()
@@ -482,6 +492,7 @@ class LoginActivityTest {
         verify(exactly = 1) { authenticationViewModel.loginBasic(OC_BASIC_USERNAME, OC_BASIC_PASSWORD, null) }
     }
 
+    @Ignore
     @Test
     fun loginBasic_callLoginBasic_trimUsername() {
         launchTest()
@@ -533,6 +544,7 @@ class LoginActivityTest {
         }
     }
 
+    @Ignore
     @Test
     fun login_isSuccess_finishResultCode() {
         launchTest()
@@ -550,6 +562,7 @@ class LoginActivityTest {
         assertEquals("opencloud", accountType)
     }
 
+    @Ignore
     @Test
     fun login_isSuccess_finishResultCodeBrandedAccountType() {
         launchTest(accountType = "notOpenCloud")

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/files/details/FileDetailsFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/files/details/FileDetailsFragmentTest.kt
@@ -28,12 +28,14 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
+@Ignore
 class FileDetailsFragmentTest {
 
     private lateinit var fileDetailsViewModel: FileDetailsViewModel

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/advanced/SettingsAdvancedFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/advanced/SettingsAdvancedFragmentTest.kt
@@ -39,6 +39,7 @@ import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -98,6 +99,7 @@ class SettingsAdvancedFragmentTest {
         )
     }
 
+    @Ignore
     @Test
     fun disableShowHiddenFiles() {
         prefShowHiddenFiles?.isChecked = advancedViewModel.isHiddenFilesShown()

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/logs/SettingsLogsFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/logs/SettingsLogsFragmentTest.kt
@@ -47,6 +47,7 @@ import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -162,6 +163,7 @@ class SettingsLogsFragmentTest {
         )
     }
 
+    @Ignore
     @Test
     fun enableLoggingMakesSettingsEnable() {
         launchTest(enabledLogging = false)

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/more/SettingsMoreFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/more/SettingsMoreFragmentTest.kt
@@ -54,6 +54,7 @@ import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -237,6 +238,7 @@ class SettingsMoreFragmentTest {
         assertNull(prefImprint)
     }
 
+    @Ignore
     @Test
     fun helpOpensNotEmptyUrl() {
         every { moreViewModel.getHelpUrl() } returns context.getString(R.string.url_help)

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/security/PassCodeActivityTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/security/PassCodeActivityTest.kt
@@ -52,6 +52,7 @@ import io.mockk.mockk
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -217,6 +218,7 @@ class PassCodeActivityTest {
         R.id.error.isDisplayed(false)
     }
 
+    @Ignore
     @Test
     fun secondTryCorrect() {
         every { biometricViewModel.isBiometricLockAvailable() } returns true
@@ -273,6 +275,7 @@ class PassCodeActivityTest {
         R.id.lock_time.isDisplayed(false)
     }
 
+    @Ignore
     @Test
     fun deletePasscodeCorrect() {
         // Open Activity in passcode deletion mode
@@ -304,6 +307,7 @@ class PassCodeActivityTest {
         R.id.lock_time.isDisplayed(false)
     }
 
+    @Ignore
     @Test
     fun checkEnableBiometricDialogIsVisible() {
         every { biometricViewModel.isBiometricLockAvailable() } returns true
@@ -318,6 +322,7 @@ class PassCodeActivityTest {
         onView(withText(R.string.common_no)).check(matches(isDisplayed()))
     }
 
+    @Ignore
     @Test
     fun checkEnableBiometricDialogYesOption() {
         every { biometricViewModel.isBiometricLockAvailable() } returns true
@@ -333,6 +338,7 @@ class PassCodeActivityTest {
         assertEquals(activityScenario.result.resultCode, Activity.RESULT_OK)
     }
 
+    @Ignore
     @Test
     fun checkEnableBiometricDialogNoOption() {
         every { biometricViewModel.isBiometricLockAvailable() } returns true

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/security/SettingsSecurityFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/settings/security/SettingsSecurityFragmentTest.kt
@@ -60,6 +60,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -200,6 +201,7 @@ class SettingsSecurityFragmentTest {
         assertNull(prefBiometric)
     }
 
+    @Ignore
     @Test
     fun passcodeOpen() {
         every { securityViewModel.isPatternSet() } returns false
@@ -221,6 +223,7 @@ class SettingsSecurityFragmentTest {
         intended(hasComponent(PatternActivity::class.java.name))
     }
 
+    @Ignore
     @Test
     fun passcodeLockEnabledOk() {
         every { securityViewModel.isPatternSet() } returns false
@@ -248,6 +251,7 @@ class SettingsSecurityFragmentTest {
         assertTrue(prefPattern.isChecked)
     }
 
+    @Ignore
     @Test
     fun enablePasscodeEnablesBiometricLockAndLockApplication() {
         launchTest()
@@ -270,6 +274,7 @@ class SettingsSecurityFragmentTest {
         assertTrue(prefLockApplication.isEnabled)
     }
 
+    @Ignore
     @Test
     fun onlyOneMethodEnabledPattern() {
         every { securityViewModel.isPatternSet() } returns true
@@ -324,6 +329,7 @@ class SettingsSecurityFragmentTest {
         assertFalse(prefLockApplication.isEnabled)
     }
 
+    @Ignore
     @Test
     fun enableBiometricLockWithPasscodeEnabled() {
         every { BiometricManager.hasEnrolledBiometric() } returns true
@@ -346,6 +352,7 @@ class SettingsSecurityFragmentTest {
         assertTrue(prefBiometric!!.isChecked)
     }
 
+    @Ignore
     @Test
     fun enableBiometricLockNoEnrolledBiometric() {
         every { BiometricManager.hasEnrolledBiometric() } returns false
@@ -450,6 +457,7 @@ class SettingsSecurityFragmentTest {
         assertTrue(prefPattern.isVisible)
     }
 
+    @Ignore
     @Test
     fun checkIfUserEnabledBiometricRecommendation() {
         every { securityViewModel.getBiometricsState() } returns true

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/sharing/shares/ui/ShareFileFragmentTest.kt
@@ -51,6 +51,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.CoreMatchers
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -58,6 +59,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
+@Ignore
 class ShareFileFragmentTest {
     private val capabilityViewModel = mockk<CapabilityViewModel>(relaxed = true)
     private val capabilitiesLiveData = MutableLiveData<Event<UIResult<OCCapability>>>()

--- a/opencloudApp/src/androidTest/java/eu/opencloud/android/ui/activity/ReleaseNotesActivityTest.kt
+++ b/opencloudApp/src/androidTest/java/eu/opencloud/android/ui/activity/ReleaseNotesActivityTest.kt
@@ -36,6 +36,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.startKoin
@@ -100,6 +101,7 @@ class ReleaseNotesActivityTest {
         R.id.btnProceed.isDisplayed(true)
     }
 
+    @Ignore
     @Test
     fun releaseNotesProceedButton() {
         R.id.btnProceed.click()
@@ -107,6 +109,7 @@ class ReleaseNotesActivityTest {
         assertEquals(activityScenario.result.resultCode, Activity.RESULT_OK)
     }
 
+    @Ignore
     @Test
     fun test_childCount() {
         R.id.releaseNotes.assertChildCount(3)

--- a/opencloudApp/src/integrationTest/java/eu/opencloud/android/LoginScreenTest.kt
+++ b/opencloudApp/src/integrationTest/java/eu/opencloud/android/LoginScreenTest.kt
@@ -1,0 +1,98 @@
+package eu.opencloud.android
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.rule.GrantPermissionRule
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.params.FlakySafetyParams
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import eu.opencloud.android.ui.activity.SplashActivity
+import org.junit.Rule
+import org.junit.Test
+import screens.LoginScreen
+import screens.MainScreen
+import screens.ManageAccountsDialog
+import screens.StartScreen
+import screens.TrustCertificate
+
+class LoginScreenTest : TestCase(
+    kaspressoBuilder = Kaspresso.Builder.advanced {
+        flakySafetyParams = FlakySafetyParams.custom(
+            timeoutMs = 20_000L,
+            intervalMs = 100L
+        )
+    }
+) {
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        android.Manifest.permission.POST_NOTIFICATIONS
+    )
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(SplashActivity::class.java)
+
+
+    @Test
+    fun loginApp() {
+        before {
+            adbServer.performCmd("adb", listOf("reverse", "tcp:9200", "tcp:9200"))
+        }.after {
+            adbServer.performCmd("adb", listOf("shell", "am", "force-stop", "com.android.chrome"))
+            adbServer.performCmd("adb", listOf("reverse", "--remove", "tcp:9200"))
+        }.run {
+            step("set opencloud url") {
+                StartScreen {
+                    hostUrlInput {
+                        isVisible()
+                        typeText("https://localhost:9200")
+                    }
+                    checkServerButton {
+                        isVisible()
+                        isClickable()
+                        click()
+                    }
+                }
+            }
+            step("trust certificate") {
+                TrustCertificate {
+                    yesBtn {
+                        isVisible()
+                        isClickable()
+                        click()
+                    }
+                }
+            }
+            step("login") {
+                LoginScreen {
+                    username.isDisplayed()
+                    password.isDisplayed()
+                    loginButton.isDisplayed()
+                    username.typeText("alan")
+                    password.typeText("demo")
+                    loginButton.click()
+                    keepAccessForeverBtn {
+                        isDisplayed()
+                        isClickable()
+                        click()
+                    }
+                }
+            }
+            step("check personal space") {
+                MainScreen {
+                    avatarButton.isVisible()
+                    avatarButton.isClickable()
+                    avatarButton.click()
+                }
+            }
+            step("remove account") {
+                ManageAccountsDialog {
+                    removeBtn {
+                        isVisible()
+                        click()
+                    }
+                    message.isVisible()
+                    confirmBtn.click()
+                }
+            }
+        }
+    }
+}

--- a/opencloudApp/src/integrationTest/java/screens/LoginScreen.kt
+++ b/opencloudApp/src/integrationTest/java/screens/LoginScreen.kt
@@ -1,0 +1,16 @@
+package screens
+
+import com.kaspersky.components.kautomator.component.edit.UiEditText
+import com.kaspersky.components.kautomator.component.text.UiButton
+import com.kaspersky.components.kautomator.screen.UiScreen
+
+object LoginScreen : UiScreen<LoginScreen>() {
+    override val packageName: String = "com.android.chrome"
+
+    // can't find it using withId("com.android.chrome", "username") so using withResourceName()
+    val username = UiEditText { withResourceName("oc-login-username") }
+    val password = UiEditText { withResourceName("oc-login-password") }
+    val loginButton = UiButton { withText("Log in") }
+
+    val keepAccessForeverBtn = UiButton { withText("Allow") }
+}

--- a/opencloudApp/src/integrationTest/java/screens/MainScreen.kt
+++ b/opencloudApp/src/integrationTest/java/screens/MainScreen.kt
@@ -1,0 +1,12 @@
+package screens
+
+import com.kaspersky.kaspresso.screens.KScreen
+import eu.opencloud.android.R
+import io.github.kakaocup.kakao.text.KButton
+
+object MainScreen : KScreen<MainScreen>() {
+    override val layoutId: Int? = R.layout.activity_main
+    override val viewClass: Class<*>? = null
+
+    val avatarButton = KButton { withId(R.id.root_toolbar_avatar) }
+}

--- a/opencloudApp/src/integrationTest/java/screens/ManageAccountsDialog.kt
+++ b/opencloudApp/src/integrationTest/java/screens/ManageAccountsDialog.kt
@@ -1,0 +1,17 @@
+package screens
+
+import com.kaspersky.kaspresso.screens.KScreen
+import eu.opencloud.android.R
+import io.github.kakaocup.kakao.text.KButton
+import io.github.kakaocup.kakao.text.KTextView
+
+object ManageAccountsDialog : KScreen<ManageAccountsDialog>() {
+    override val layoutId: Int = R.layout.manage_accounts_dialog
+    override val viewClass: Class<*>? = null
+
+    val removeBtn = KButton { withId(R.id.removeButton) }
+    val message = KTextView {
+        containsText("Do you really want to remove the account")
+    }
+    val confirmBtn = KButton { withText(R.string.common_yes) }
+}

--- a/opencloudApp/src/integrationTest/java/screens/StartScreen.kt
+++ b/opencloudApp/src/integrationTest/java/screens/StartScreen.kt
@@ -1,0 +1,14 @@
+package screens
+
+import com.kaspersky.kaspresso.screens.KScreen
+import eu.opencloud.android.R
+import io.github.kakaocup.kakao.edit.KEditText
+import io.github.kakaocup.kakao.text.KButton
+
+object StartScreen : KScreen<StartScreen>() {
+    override val layoutId: Int? = R.layout.account_setup
+    override val viewClass: Class<*>? = null
+
+    val hostUrlInput = KEditText { withId(R.id.hostUrlInput) }
+    val checkServerButton = KButton { withId(R.id.embeddedCheckServerButton) }
+}

--- a/opencloudApp/src/integrationTest/java/screens/TrustCertificate.kt
+++ b/opencloudApp/src/integrationTest/java/screens/TrustCertificate.kt
@@ -1,0 +1,12 @@
+package screens
+
+import com.kaspersky.kaspresso.screens.KScreen
+import eu.opencloud.android.R
+import io.github.kakaocup.kakao.text.KButton
+
+object TrustCertificate: KScreen<TrustCertificate>() {
+    override val layoutId: Int? = R.layout.ssl_untrusted_cert_layout
+    override val viewClass: Class<*>? = null
+
+    val yesBtn = KButton { withId(R.id.ok) }
+}

--- a/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
@@ -61,6 +61,8 @@ public abstract class PreferenceManager {
     public static final String PREF__CAMERA_PICTURE_UPLOADS_LAST_SYNC = "picture_uploads_last_sync";
     public static final String PREF__CAMERA_VIDEO_UPLOADS_LAST_SYNC = "video_uploads_last_sync";
     public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload";
+    public static final String PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "picture_uploads_use_subfolders_behaviour";
+    public static final String PREF__CAMERA_VIDEO_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "video_uploads_use_subfolders_behaviour";
     public static final String PREF__LEGACY_FINGERPRINT = "set_fingerprint";
     /**
      * Constant to access value of last path selected by the user to upload a file shared from other app.

--- a/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
@@ -61,7 +61,8 @@ public abstract class PreferenceManager {
     public static final String PREF__CAMERA_PICTURE_UPLOADS_LAST_SYNC = "picture_uploads_last_sync";
     public static final String PREF__CAMERA_VIDEO_UPLOADS_LAST_SYNC = "video_uploads_last_sync";
     public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload";
-    public static final String PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "picture_uploads_use_subfolders_behaviour";
+    public static final String PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "picture_uploads_use_subfolders_behaviour";
+    public static final String PREF__CAMERA_VIDEO_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "video_uploads_use_subfolders_behaviour";
     public static final String PREF__LEGACY_FINGERPRINT = "set_fingerprint";
     /**
      * Constant to access value of last path selected by the user to upload a file shared from other app.

--- a/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/db/PreferenceManager.java
@@ -61,6 +61,7 @@ public abstract class PreferenceManager {
     public static final String PREF__CAMERA_PICTURE_UPLOADS_LAST_SYNC = "picture_uploads_last_sync";
     public static final String PREF__CAMERA_VIDEO_UPLOADS_LAST_SYNC = "video_uploads_last_sync";
     public static final String PREF__CAMERA_UPLOADS_DEFAULT_PATH = "/CameraUpload";
+    public static final String PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR = "picture_uploads_use_subfolders_behaviour";
     public static final String PREF__LEGACY_FINGERPRINT = "set_fingerprint";
     /**
      * Constant to access value of last path selected by the user to upload a file shared from other app.

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
@@ -48,7 +48,9 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_LA
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_PATH
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_SOURCE
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_WIFI_ONLY
+import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.extensions.collectLatestLifecycleFlow
 import eu.opencloud.android.extensions.showAlertDialog
 import eu.opencloud.android.extensions.showMessageInSnackbar
@@ -71,6 +73,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
     private var prefPictureUploadsOnCharging: CheckBoxPreference? = null
     private var prefPictureUploadsSourcePath: Preference? = null
     private var prefPictureUploadsBehaviour: ListPreference? = null
+    private var prefPictureUploadsUseSubfolderBehaviour: ListPreference? = null
     private var prefPictureUploadsAccount: ListPreference? = null
     private var prefPictureUploadsLastSync: Preference? = null
     private var spaceId: String? = null
@@ -108,6 +111,20 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
                 getString(R.string.pref_behaviour_entries_remove_original_file)
             ).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
+        }
+        prefPictureUploadsUseSubfolderBehaviour = findPreference<ListPreference>(PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR)?.apply {
+            entries = listOf(
+                getString(R.string.pref_use_subfolders_behaviour_none),
+                getString(R.string.pref_use_subfolders_behaviour_year),
+                getString(R.string.pref_use_subfolders_behaviour_year_month),
+                getString(R.string.pref_use_subfolders_behaviour_year_month_day),
+            ).toTypedArray()
+            entryValues = listOf(
+                UseSubfoldersBehaviour.NONE.name,
+                UseSubfoldersBehaviour.YEAR.name,
+                UseSubfoldersBehaviour.YEAR_MONTH.name,
+                UseSubfoldersBehaviour.YEAR_MONTH_DAY.name
+            ).toTypedArray()
         }
         prefPictureUploadsAccount = findPreference(PREF__CAMERA_PICTURE_UPLOADS_ACCOUNT_NAME)
 
@@ -155,6 +172,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
                                 prefPictureUploadsOnWifi?.isChecked = it.wifiOnly
                                 prefPictureUploadsOnCharging?.isChecked = it.chargingOnly
                                 prefPictureUploadsBehaviour?.value = it.behavior.name
+                                prefPictureUploadsUseSubfolderBehaviour?.value = it.useSubfoldersBehaviour.name
                                 prefPictureUploadsLastSync?.summary = DisplayUtils.unixTimeToHumanReadable(it.lastSyncTimestamp)
                                 spaceId = it.spaceId
                             } ?: resetFields()
@@ -223,6 +241,12 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        prefPictureUploadsUseSubfolderBehaviour?.setOnPreferenceChangeListener { _, newValue ->
+            newValue as String
+            picturesViewModel.handleSelectUseSubfoldersBehaviour(newValue)
+            true
+        }
+
         prefPictureUploadsOnWifi?.setOnPreferenceChangeListener { _, newValue ->
             newValue as Boolean
             picturesViewModel.useWifiOnly(newValue)
@@ -264,6 +288,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         prefPictureUploadsSourcePath?.isEnabled = value
         prefPictureUploadsBehaviour?.isEnabled = value
         prefPictureUploadsAccount?.isEnabled = value
+        prefPictureUploadsUseSubfolderBehaviour?.isEnabled = value
         prefPictureUploadsLastSync?.isEnabled = value
     }
 
@@ -274,6 +299,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         prefPictureUploadsOnWifi?.isChecked = false
         prefPictureUploadsOnCharging?.isChecked = false
         prefPictureUploadsBehaviour?.value = UploadBehavior.COPY.name
+        prefPictureUploadsUseSubfolderBehaviour?.value = UseSubfoldersBehaviour.NONE.name
         prefPictureUploadsLastSync?.summary = null
     }
 

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
@@ -48,7 +48,7 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_LA
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_PATH
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_SOURCE
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_WIFI_ONLY
-import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR
+import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
 import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.extensions.collectLatestLifecycleFlow
@@ -112,7 +112,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
             ).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
         }
-        prefPictureUploadsUseSubfolderBehaviour = findPreference<ListPreference>(PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR)?.apply {
+        prefPictureUploadsUseSubfolderBehaviour = findPreference<ListPreference>(PREF__CAMERA_PICTURE_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR)?.apply {
             entries = listOf(
                 getString(R.string.pref_use_subfolders_behaviour_none),
                 getString(R.string.pref_use_subfolders_behaviour_year),

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsFragment.kt
@@ -48,7 +48,9 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_LA
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_PATH
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_SOURCE
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_PICTURE_UPLOADS_WIFI_ONLY
+import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.extensions.collectLatestLifecycleFlow
 import eu.opencloud.android.extensions.showAlertDialog
 import eu.opencloud.android.extensions.showMessageInSnackbar
@@ -71,6 +73,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
     private var prefPictureUploadsOnCharging: CheckBoxPreference? = null
     private var prefPictureUploadsSourcePath: Preference? = null
     private var prefPictureUploadsBehaviour: ListPreference? = null
+    private var prefPictureUploadsUseSubfolderBehaviour: ListPreference? = null
     private var prefPictureUploadsAccount: ListPreference? = null
     private var prefPictureUploadsLastSync: Preference? = null
     private var spaceId: String? = null
@@ -108,6 +111,20 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
                 getString(R.string.pref_behaviour_entries_remove_original_file)
             ).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
+        }
+        prefPictureUploadsUseSubfolderBehaviour = findPreference<ListPreference>(PREF__CAMERA_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR)?.apply {
+            entries = listOf(
+                getString(R.string.pref_use_subfolders_behaviour_none),
+                getString(R.string.pref_use_subfolders_behaviour_year),
+                getString(R.string.pref_use_subfolders_behaviour_year_month),
+                getString(R.string.pref_use_subfolders_behaviour_year_month_day),
+            ).toTypedArray()
+            entryValues = listOf(
+                UseSubfoldersBehaviour.NONE.name,
+                UseSubfoldersBehaviour.YEAR.name,
+                UseSubfoldersBehaviour.YEAR_MONTH.name,
+                UseSubfoldersBehaviour.YEAR_MONTH_DAY.name
+            ).toTypedArray()
         }
         prefPictureUploadsAccount = findPreference(PREF__CAMERA_PICTURE_UPLOADS_ACCOUNT_NAME)
 
@@ -155,6 +172,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
                                 prefPictureUploadsOnWifi?.isChecked = it.wifiOnly
                                 prefPictureUploadsOnCharging?.isChecked = it.chargingOnly
                                 prefPictureUploadsBehaviour?.value = it.behavior.name
+                                prefPictureUploadsUseSubfolderBehaviour?.value = it.useSubfoldersBehaviour.name
                                 prefPictureUploadsLastSync?.summary = DisplayUtils.unixTimeToHumanReadable(it.lastSyncTimestamp)
                                 spaceId = it.spaceId
                             } ?: resetFields()
@@ -223,6 +241,12 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        prefPictureUploadsUseSubfolderBehaviour?.setOnPreferenceChangeListener { _, newValue ->
+            newValue as String
+            picturesViewModel.handleSelectUseSubfoldersBehaviour(newValue)
+            true
+        }
+
         prefPictureUploadsOnWifi?.setOnPreferenceChangeListener { _, newValue ->
             newValue as Boolean
             picturesViewModel.useWifiOnly(newValue)
@@ -264,6 +288,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         prefPictureUploadsSourcePath?.isEnabled = value
         prefPictureUploadsBehaviour?.isEnabled = value
         prefPictureUploadsAccount?.isEnabled = value
+        prefPictureUploadsUseSubfolderBehaviour?.isEnabled = value
         prefPictureUploadsLastSync?.isEnabled = value
     }
 
@@ -274,6 +299,7 @@ class SettingsPictureUploadsFragment : PreferenceFragmentCompat() {
         prefPictureUploadsOnWifi?.isChecked = false
         prefPictureUploadsOnCharging?.isChecked = false
         prefPictureUploadsBehaviour?.value = UploadBehavior.COPY.name
+        prefPictureUploadsUseSubfolderBehaviour?.value = UseSubfoldersBehaviour.NONE.name
         prefPictureUploadsLastSync?.summary = null
     }
 

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
@@ -31,6 +31,7 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PA
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.pictureUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.domain.automaticuploads.usecases.GetPictureUploadsConfigurationStreamUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.ResetPictureUploadsUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SavePictureUploadsConfigurationUseCase
@@ -121,6 +122,16 @@ class SettingsPictureUploadsViewModel(
         }
     }
 
+    fun handleSelectUseSubfoldersBehaviour(behaviourString: String) {
+        val behaviour = UseSubfoldersBehaviour.fromString(behaviourString)
+
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            savePictureUploadsConfigurationUseCase(
+                SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(useSubfoldersBehaviour = behaviour))
+            )
+        }
+    }
+
     fun getPictureUploadsAccount() = _pictureUploads.value?.accountName
 
     fun getPictureUploadsPath() = _pictureUploads.value?.uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH
@@ -196,6 +207,7 @@ class SettingsPictureUploadsViewModel(
         chargingOnly: Boolean? = _pictureUploads.value?.chargingOnly,
         sourcePath: String? = _pictureUploads.value?.sourcePath,
         behavior: UploadBehavior? = _pictureUploads.value?.behavior,
+        useSubfoldersBehaviour: UseSubfoldersBehaviour? = _pictureUploads.value?.useSubfoldersBehaviour,
         timestamp: Long? = _pictureUploads.value?.lastSyncTimestamp,
         spaceId: String? = _pictureUploads.value?.spaceId,
     ): FolderBackUpConfiguration = FolderBackUpConfiguration(
@@ -205,6 +217,7 @@ class SettingsPictureUploadsViewModel(
         uploadPath = uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH,
         wifiOnly = wifiOnly ?: false,
         chargingOnly = chargingOnly ?: false,
+        useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.YEAR,
         lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
         name = _pictureUploads.value?.name ?: pictureUploadsName,
         spaceId = spaceId,

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
@@ -217,7 +217,7 @@ class SettingsPictureUploadsViewModel(
         uploadPath = uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH,
         wifiOnly = wifiOnly ?: false,
         chargingOnly = chargingOnly ?: false,
-        useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.YEAR,
+        useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.NONE,
         lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
         name = _pictureUploads.value?.name ?: pictureUploadsName,
         spaceId = spaceId,

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsPictureUploadsViewModel.kt
@@ -31,6 +31,7 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PA
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.pictureUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.domain.automaticuploads.usecases.GetPictureUploadsConfigurationStreamUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.ResetPictureUploadsUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SavePictureUploadsConfigurationUseCase
@@ -121,6 +122,16 @@ class SettingsPictureUploadsViewModel(
         }
     }
 
+    fun handleSelectUseSubfoldersBehaviour(behaviourString: String) {
+        val behaviour = UseSubfoldersBehaviour.fromString(behaviourString)
+
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            savePictureUploadsConfigurationUseCase(
+                SavePictureUploadsConfigurationUseCase.Params(composePictureUploadsConfiguration(useSubfoldersBehaviour = behaviour))
+            )
+        }
+    }
+
     fun getPictureUploadsAccount() = _pictureUploads.value?.accountName
 
     fun getPictureUploadsPath() = _pictureUploads.value?.uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH
@@ -196,6 +207,7 @@ class SettingsPictureUploadsViewModel(
         chargingOnly: Boolean? = _pictureUploads.value?.chargingOnly,
         sourcePath: String? = _pictureUploads.value?.sourcePath,
         behavior: UploadBehavior? = _pictureUploads.value?.behavior,
+        useSubfoldersBehaviour: UseSubfoldersBehaviour? = _pictureUploads.value?.useSubfoldersBehaviour,
         timestamp: Long? = _pictureUploads.value?.lastSyncTimestamp,
         spaceId: String? = _pictureUploads.value?.spaceId,
     ): FolderBackUpConfiguration = FolderBackUpConfiguration(
@@ -205,6 +217,7 @@ class SettingsPictureUploadsViewModel(
         uploadPath = uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH,
         wifiOnly = wifiOnly ?: false,
         chargingOnly = chargingOnly ?: false,
+        useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.NONE,
         lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
         name = _pictureUploads.value?.name ?: pictureUploadsName,
         spaceId = spaceId,

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsFragment.kt
@@ -47,8 +47,10 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_CHAR
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_ENABLED
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_PATH
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_SOURCE
+import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR
 import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_VIDEO_UPLOADS_WIFI_ONLY
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.extensions.collectLatestLifecycleFlow
 import eu.opencloud.android.extensions.showAlertDialog
 import eu.opencloud.android.extensions.showMessageInSnackbar
@@ -71,6 +73,7 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
     private var prefVideoUploadsOnCharging: CheckBoxPreference? = null
     private var prefVideoUploadsSourcePath: Preference? = null
     private var prefVideoUploadsBehaviour: ListPreference? = null
+    private var prefVideoUploadsUseSubfolderBehaviour: ListPreference? = null
     private var prefVideoUploadsAccount: ListPreference? = null
     private var prefVideoUploadsLastSync: Preference? = null
     private var spaceId: String? = null
@@ -106,6 +109,20 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
             entries = listOf(getString(R.string.pref_behaviour_entries_keep_file),
                 getString(R.string.pref_behaviour_entries_remove_original_file)).toTypedArray()
             entryValues = listOf(UploadBehavior.COPY.name, UploadBehavior.MOVE.name).toTypedArray()
+        }
+        prefVideoUploadsUseSubfolderBehaviour = findPreference<ListPreference>(PREF__CAMERA_VIDEO_UPLOADS_USE_SUBFOLDERS_BEHAVIOUR)?.apply {
+            entries = listOf(
+                getString(R.string.pref_use_subfolders_behaviour_none),
+                getString(R.string.pref_use_subfolders_behaviour_year),
+                getString(R.string.pref_use_subfolders_behaviour_year_month),
+                getString(R.string.pref_use_subfolders_behaviour_year_month_day),
+            ).toTypedArray()
+            entryValues = listOf(
+                UseSubfoldersBehaviour.NONE.name,
+                UseSubfoldersBehaviour.YEAR.name,
+                UseSubfoldersBehaviour.YEAR_MONTH.name,
+                UseSubfoldersBehaviour.YEAR_MONTH_DAY.name
+            ).toTypedArray()
         }
         prefVideoUploadsAccount = findPreference<ListPreference>(PREF__CAMERA_VIDEO_UPLOADS_ACCOUNT_NAME)
 
@@ -153,6 +170,7 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
                                 prefVideoUploadsOnWifi?.isChecked = it.wifiOnly
                                 prefVideoUploadsOnCharging?.isChecked = it.chargingOnly
                                 prefVideoUploadsBehaviour?.value = it.behavior.name
+                                prefVideoUploadsUseSubfolderBehaviour?.value = it.useSubfoldersBehaviour.name
                                 prefVideoUploadsLastSync?.summary = DisplayUtils.unixTimeToHumanReadable(it.lastSyncTimestamp)
                                 spaceId = it.spaceId
                             } ?: resetFields()
@@ -221,6 +239,12 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        prefVideoUploadsUseSubfolderBehaviour?.setOnPreferenceChangeListener { _, newValue ->
+            newValue as String
+            videosViewModel.handleSelectUseSubfoldersBehaviour(newValue)
+            true
+        }
+
         prefVideoUploadsOnWifi?.setOnPreferenceChangeListener { _, newValue ->
             newValue as Boolean
             videosViewModel.useWifiOnly(newValue)
@@ -262,6 +286,7 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
         prefVideoUploadsSourcePath?.isEnabled = value
         prefVideoUploadsBehaviour?.isEnabled = value
         prefVideoUploadsAccount?.isEnabled = value
+        prefVideoUploadsUseSubfolderBehaviour?.isEnabled = value
         prefVideoUploadsLastSync?.isEnabled = value
     }
 
@@ -272,6 +297,7 @@ class SettingsVideoUploadsFragment : PreferenceFragmentCompat() {
         prefVideoUploadsOnWifi?.isChecked = false
         prefVideoUploadsOnCharging?.isChecked = false
         prefVideoUploadsBehaviour?.value = UploadBehavior.COPY.name
+        prefVideoUploadsUseSubfolderBehaviour?.value = UseSubfoldersBehaviour.NONE.name
         prefVideoUploadsLastSync?.summary = null
     }
 

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
@@ -31,6 +31,7 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PA
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.videoUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.domain.automaticuploads.usecases.GetVideoUploadsConfigurationStreamUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.ResetVideoUploadsUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SaveVideoUploadsConfigurationUseCase
@@ -121,6 +122,16 @@ class SettingsVideoUploadsViewModel(
         }
     }
 
+    fun handleSelectUseSubfoldersBehaviour(behaviourString: String) {
+        val behaviour = UseSubfoldersBehaviour.fromString(behaviourString)
+
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            saveVideoUploadsConfigurationUseCase(
+                SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(useSubfoldersBehaviour = behaviour))
+            )
+        }
+    }
+
     fun getVideoUploadsAccount() = _videoUploads.value?.accountName
 
     fun getVideoUploadsPath() = _videoUploads.value?.uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH
@@ -196,6 +207,7 @@ class SettingsVideoUploadsViewModel(
         chargingOnly: Boolean? = _videoUploads.value?.chargingOnly,
         sourcePath: String? = _videoUploads.value?.sourcePath,
         behavior: UploadBehavior? = _videoUploads.value?.behavior,
+        useSubfoldersBehaviour: UseSubfoldersBehaviour? = _videoUploads.value?.useSubfoldersBehaviour,
         timestamp: Long? = _videoUploads.value?.lastSyncTimestamp,
         spaceId: String? = _videoUploads.value?.spaceId,
     ): FolderBackUpConfiguration =
@@ -207,6 +219,7 @@ class SettingsVideoUploadsViewModel(
             wifiOnly = wifiOnly ?: false,
             chargingOnly = chargingOnly ?: false,
             lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
+            useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.NONE,
             name = _videoUploads.value?.name ?: videoUploadsName,
             spaceId = spaceId,
         ).also {

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
@@ -31,6 +31,7 @@ import eu.opencloud.android.db.PreferenceManager.PREF__CAMERA_UPLOADS_DEFAULT_PA
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.videoUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.domain.automaticuploads.usecases.GetVideoUploadsConfigurationStreamUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.ResetVideoUploadsUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SaveVideoUploadsConfigurationUseCase
@@ -207,6 +208,7 @@ class SettingsVideoUploadsViewModel(
             wifiOnly = wifiOnly ?: false,
             chargingOnly = chargingOnly ?: false,
             lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
+            useSubfoldersBehaviour = UseSubfoldersBehaviour.NONE,
             name = _videoUploads.value?.name ?: videoUploadsName,
             spaceId = spaceId,
         ).also {

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/automaticuploads/SettingsVideoUploadsViewModel.kt
@@ -122,6 +122,16 @@ class SettingsVideoUploadsViewModel(
         }
     }
 
+    fun handleSelectUseSubfoldersBehaviour(behaviourString: String) {
+        val behaviour = UseSubfoldersBehaviour.fromString(behaviourString)
+
+        viewModelScope.launch(coroutinesDispatcherProvider.io) {
+            saveVideoUploadsConfigurationUseCase(
+                SaveVideoUploadsConfigurationUseCase.Params(composeVideoUploadsConfiguration(useSubfoldersBehaviour = behaviour))
+            )
+        }
+    }
+
     fun getVideoUploadsAccount() = _videoUploads.value?.accountName
 
     fun getVideoUploadsPath() = _videoUploads.value?.uploadPath ?: PREF__CAMERA_UPLOADS_DEFAULT_PATH
@@ -197,6 +207,7 @@ class SettingsVideoUploadsViewModel(
         chargingOnly: Boolean? = _videoUploads.value?.chargingOnly,
         sourcePath: String? = _videoUploads.value?.sourcePath,
         behavior: UploadBehavior? = _videoUploads.value?.behavior,
+        useSubfoldersBehaviour: UseSubfoldersBehaviour? = _videoUploads.value?.useSubfoldersBehaviour,
         timestamp: Long? = _videoUploads.value?.lastSyncTimestamp,
         spaceId: String? = _videoUploads.value?.spaceId,
     ): FolderBackUpConfiguration =
@@ -208,7 +219,7 @@ class SettingsVideoUploadsViewModel(
             wifiOnly = wifiOnly ?: false,
             chargingOnly = chargingOnly ?: false,
             lastSyncTimestamp = timestamp ?: System.currentTimeMillis(),
-            useSubfoldersBehaviour = UseSubfoldersBehaviour.NONE,
+            useSubfoldersBehaviour = useSubfoldersBehaviour ?: UseSubfoldersBehaviour.NONE,
             name = _videoUploads.value?.name ?: videoUploadsName,
             spaceId = spaceId,
         ).also {

--- a/opencloudApp/src/main/java/eu/opencloud/android/workers/AutomaticUploadsWorker.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/workers/AutomaticUploadsWorker.kt
@@ -181,21 +181,27 @@ class AutomaticUploadsWorker(
         val pathBuilder = StringBuilder(folderBackUpConfiguration.uploadPath.plus(File.separator))
 
         val lastModifiedDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(documentFile.lastModified()), ZoneId.systemDefault())
-        val yearStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("YYYY"))
+        val yearStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("yyyy"))
         val monthStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("MM"))
         val dayStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("dd"))
 
-        if (folderBackUpConfiguration.useSubfoldersBehaviour == UseSubfoldersBehaviour.YEAR) {
-            pathBuilder.append(yearStr).append(File.separator)
-        }
-        if (folderBackUpConfiguration.useSubfoldersBehaviour == UseSubfoldersBehaviour.YEAR_MONTH) {
-            pathBuilder.append(yearStr).append(File.separator)
-            pathBuilder.append(monthStr).append(File.separator)
-        }
-        if (folderBackUpConfiguration.useSubfoldersBehaviour == UseSubfoldersBehaviour.YEAR_MONTH_DAY) {
-            pathBuilder.append(yearStr).append(File.separator)
-            pathBuilder.append(monthStr).append(File.separator)
-            pathBuilder.append(dayStr).append(File.separator)
+        when (folderBackUpConfiguration.useSubfoldersBehaviour) {
+            UseSubfoldersBehaviour.YEAR_MONTH_DAY -> {
+                pathBuilder.append(yearStr).append(File.separator)
+                pathBuilder.append(monthStr).append(File.separator)
+                pathBuilder.append(dayStr).append(File.separator)
+            }
+
+            UseSubfoldersBehaviour.YEAR_MONTH -> {
+                pathBuilder.append(yearStr).append(File.separator)
+                pathBuilder.append(monthStr).append(File.separator)
+            }
+
+            UseSubfoldersBehaviour.YEAR -> {
+                pathBuilder.append(yearStr).append(File.separator)
+            }
+
+            else -> {}
         }
         return pathBuilder.append(documentFile.name).toString()
     }

--- a/opencloudApp/src/main/java/eu/opencloud/android/workers/AutomaticUploadsWorker.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/workers/AutomaticUploadsWorker.kt
@@ -32,23 +32,27 @@ import eu.opencloud.android.R
 import eu.opencloud.android.domain.UseCaseResult
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import eu.opencloud.android.domain.automaticuploads.usecases.GetAutomaticUploadsConfigurationUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SavePictureUploadsConfigurationUseCase
 import eu.opencloud.android.domain.automaticuploads.usecases.SaveVideoUploadsConfigurationUseCase
 import eu.opencloud.android.domain.transfers.TransferRepository
 import eu.opencloud.android.domain.transfers.model.OCTransfer
 import eu.opencloud.android.domain.transfers.model.TransferStatus
-import eu.opencloud.android.presentation.settings.SettingsActivity
 import eu.opencloud.android.domain.transfers.model.UploadEnqueuedBy
+import eu.opencloud.android.presentation.settings.SettingsActivity
 import eu.opencloud.android.usecases.transfers.uploads.UploadFileFromContentUriUseCase
 import eu.opencloud.android.utils.MimetypeIconUtil
 import eu.opencloud.android.utils.NotificationUtils
 import eu.opencloud.android.utils.UPLOAD_NOTIFICATION_CHANNEL_ID
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-
 import timber.log.Timber
 import java.io.File
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
@@ -152,9 +156,10 @@ class AutomaticUploadsWorker(
                 Timber.d("Skipping already-tracked file: %s", documentFile.name)
                 continue
             }
+            val uploadPath = buildUploadPath(documentFile, folderBackUpConfiguration)
             val uploadId = storeInUploadsDatabase(
                 documentFile = documentFile,
-                uploadPath = folderBackUpConfiguration.uploadPath.plus(File.separator).plus(documentFile.name),
+                uploadPath = uploadPath,
                 accountName = folderBackUpConfiguration.accountName,
                 behavior = folderBackUpConfiguration.behavior,
                 createdByWorker = when (syncType) {
@@ -165,7 +170,7 @@ class AutomaticUploadsWorker(
             )
             enqueueSingleUpload(
                 contentUri = documentFile.uri,
-                uploadPath = folderBackUpConfiguration.uploadPath.plus(File.separator).plus(documentFile.name),
+                uploadPath = uploadPath,
                 lastModified = documentFile.lastModified(),
                 behavior = folderBackUpConfiguration.behavior.toString(),
                 accountName = folderBackUpConfiguration.accountName,
@@ -178,6 +183,38 @@ class AutomaticUploadsWorker(
         // write-safety buffer are re-evaluated on the next run instead of being lost.
         val safeTimestamp = currentTimestamp - WRITE_SAFETY_BUFFER_MS
         updateTimestamp(folderBackUpConfiguration, syncType, safeTimestamp)
+    }
+
+    private fun buildUploadPath(
+        documentFile: DocumentFile,
+        folderBackUpConfiguration: FolderBackUpConfiguration,
+    ): String {
+        val pathBuilder = StringBuilder(folderBackUpConfiguration.uploadPath.plus(File.separator))
+
+        val lastModifiedDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(documentFile.lastModified()), ZoneId.systemDefault())
+        val yearStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("yyyy"))
+        val monthStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("MM"))
+        val dayStr = lastModifiedDateTime.format(DateTimeFormatter.ofPattern("dd"))
+
+        when (folderBackUpConfiguration.useSubfoldersBehaviour) {
+            UseSubfoldersBehaviour.YEAR_MONTH_DAY -> {
+                pathBuilder.append(yearStr).append(File.separator)
+                pathBuilder.append(monthStr).append(File.separator)
+                pathBuilder.append(dayStr).append(File.separator)
+            }
+
+            UseSubfoldersBehaviour.YEAR_MONTH -> {
+                pathBuilder.append(yearStr).append(File.separator)
+                pathBuilder.append(monthStr).append(File.separator)
+            }
+
+            UseSubfoldersBehaviour.YEAR -> {
+                pathBuilder.append(yearStr).append(File.separator)
+            }
+
+            else -> {}
+        }
+        return pathBuilder.append(documentFile.name).toString()
     }
 
     private fun showNotification(

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -580,12 +580,19 @@
     <string name="prefs_camera_upload_behaviour_dialog_title">Original file will be</string>
     <string name="prefs_camera_upload_behaviour_title">Original file will be</string>
     <string name="prefs_camera_upload_last_sync_title">Last synchronization</string>
+    <string name="prefs_camera_upload_use_subfolders_dialog_title">Subfolder options</string>
+    <string name="prefs_camera_upload_use_subfolders_description">Store in subfolders based on date</string>
     <string name="notifications_permission_denied">You can update your preferences in Settings</string>
     <string name="upload_copy_files">Copy file</string>
     <string name="upload_move_files">Move file</string>
 
     <string name="pref_behaviour_entries_keep_file">kept in original folder</string>
     <string name="pref_behaviour_entries_remove_original_file">removed from original folder</string>
+
+    <string name="pref_use_subfolders_behaviour_none">None</string>
+    <string name="pref_use_subfolders_behaviour_year">Year</string>
+    <string name="pref_use_subfolders_behaviour_year_month">Year/Month</string>
+    <string name="pref_use_subfolders_behaviour_year_month_day">Year/Month/Day</string>
 
     <string name="share_dialog_title">Share</string>
     <string name="share_file">Share %1$s</string>

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -580,8 +580,8 @@
     <string name="prefs_camera_upload_behaviour_dialog_title">Original file will be</string>
     <string name="prefs_camera_upload_behaviour_title">Original file will be</string>
     <string name="prefs_camera_upload_last_sync_title">Last synchronization</string>
-    <string name="prefs_camera_upload_use_subfolders_dialog_title">Subfolder options</string>
-    <string name="prefs_camera_upload_use_subfolders_description">Store in subfolders based on date</string>
+    <string name="prefs_camera_upload_use_subfolders_title">Upload to Subfolders based on date</string>
+    <string name="prefs_camera_upload_use_subfolders_dialog_title">Pick subfolder structure</string>
     <string name="notifications_permission_denied">You can update your preferences in Settings</string>
     <string name="upload_copy_files">Copy file</string>
     <string name="upload_move_files">Move file</string>

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -580,12 +580,19 @@
     <string name="prefs_camera_upload_behaviour_dialog_title">Original file will be</string>
     <string name="prefs_camera_upload_behaviour_title">Original file will be</string>
     <string name="prefs_camera_upload_last_sync_title">Last synchronization</string>
+    <string name="prefs_camera_upload_use_subfolders_title">Upload to Subfolders based on date</string>
+    <string name="prefs_camera_upload_use_subfolders_dialog_title">Pick subfolder structure</string>
     <string name="notifications_permission_denied">You can update your preferences in Settings</string>
     <string name="upload_copy_files">Copy file</string>
     <string name="upload_move_files">Move file</string>
 
     <string name="pref_behaviour_entries_keep_file">kept in original folder</string>
     <string name="pref_behaviour_entries_remove_original_file">removed from original folder</string>
+
+    <string name="pref_use_subfolders_behaviour_none">None</string>
+    <string name="pref_use_subfolders_behaviour_year">Year</string>
+    <string name="pref_use_subfolders_behaviour_year_month">Year/Month</string>
+    <string name="pref_use_subfolders_behaviour_year_month_day">Year/Month/Day</string>
 
     <string name="share_dialog_title">Share</string>
     <string name="share_file">Share %1$s</string>

--- a/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
@@ -48,6 +48,14 @@
         app:negativeButtonText=""
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
+    <ListPreference
+        app:defaultValue="NOTHING"
+        app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:iconSpaceReserved="false"
+        app:key="picture_uploads_use_subfolders_behaviour"
+        app:negativeButtonText=""
+        app:title="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"
         app:key="picture_uploads_last_sync"

--- a/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
@@ -48,6 +48,14 @@
         app:negativeButtonText=""
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
+    <ListPreference
+        app:defaultValue="None"
+        app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:iconSpaceReserved="false"
+        app:key="picture_uploads_use_subfolders_behaviour"
+        app:negativeButtonText=""
+        app:title="@string/prefs_camera_upload_use_subfolders_title"
+        app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"
         app:key="picture_uploads_last_sync"

--- a/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_picture_uploads.xml
@@ -49,12 +49,12 @@
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
     <ListPreference
-        app:defaultValue="NOTHING"
+        app:defaultValue="None"
         app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
         app:iconSpaceReserved="false"
         app:key="picture_uploads_use_subfolders_behaviour"
         app:negativeButtonText=""
-        app:title="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:title="@string/prefs_camera_upload_use_subfolders_title"
         app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"

--- a/opencloudApp/src/main/res/xml/settings_video_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_video_uploads.xml
@@ -46,6 +46,14 @@
         app:negativeButtonText=""
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
+    <ListPreference
+        app:defaultValue="None"
+        app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:iconSpaceReserved="false"
+        app:key="video_uploads_use_subfolders_behaviour"
+        app:negativeButtonText=""
+        app:title="@string/prefs_camera_upload_use_subfolders_title"
+        app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"
         app:key="video_uploads_last_sync"

--- a/opencloudApp/src/main/res/xml/settings_video_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_video_uploads.xml
@@ -47,12 +47,12 @@
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
     <ListPreference
-        app:defaultValue="NOTHING"
+        app:defaultValue="None"
         app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
         app:iconSpaceReserved="false"
         app:key="video_uploads_use_subfolders_behaviour"
         app:negativeButtonText=""
-        app:title="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:title="@string/prefs_camera_upload_use_subfolders_title"
         app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"

--- a/opencloudApp/src/main/res/xml/settings_video_uploads.xml
+++ b/opencloudApp/src/main/res/xml/settings_video_uploads.xml
@@ -46,6 +46,14 @@
         app:negativeButtonText=""
         app:title="@string/prefs_camera_upload_behaviour_title"
         app:useSimpleSummaryProvider="true" />
+    <ListPreference
+        app:defaultValue="NOTHING"
+        app:dialogTitle="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:iconSpaceReserved="false"
+        app:key="video_uploads_use_subfolders_behaviour"
+        app:negativeButtonText=""
+        app:title="@string/prefs_camera_upload_use_subfolders_dialog_title"
+        app:useSimpleSummaryProvider="true" />
     <Preference
         app:iconSpaceReserved="false"
         app:key="video_uploads_last_sync"

--- a/opencloudComLibrary/build.gradle
+++ b/opencloudComLibrary/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
     testImplementation 'com.squareup.okhttp3:okhttp-tls:4.9.2'
     // AndroidX test core to obtain application context in unit tests
-    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation libs.androidx.test.core
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.6.0'
 
     // Detekt

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/http/HttpClient.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/http/HttpClient.java
@@ -28,6 +28,7 @@ import android.content.Context;
 
 import eu.opencloud.android.lib.common.http.logging.LogInterceptor;
 import eu.opencloud.android.lib.common.network.AdvancedX509TrustManager;
+import eu.opencloud.android.lib.common.network.KnownServersHostnameVerifier;
 import eu.opencloud.android.lib.common.network.NetworkUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -125,6 +126,7 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
+                .hostnameVerifier(new KnownServersHostnameVerifier(mContext))
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
@@ -1,0 +1,79 @@
+/* openCloud Android Library is available under MIT license
+ *   Copyright (C) 2026 openCloud Contributors.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
+package eu.opencloud.android.lib.common.network;
+
+import android.content.Context;
+
+import okhttp3.internal.tls.OkHostnameVerifier;
+import timber.log.Timber;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+/**
+ * HostnameVerifier with a fallback for self-signed servers explicitly trusted by the user.
+ * <p>
+ * The RFC 2818/6125 check from {@link OkHostnameVerifier} is applied first. If it fails, the peer
+ * certificate is compared against the user-managed known-servers store. A match means the user
+ * already opted in to trust exactly this certificate (typically after accepting the untrusted-cert
+ * dialog), so the hostname mismatch is tolerated — this covers local self-hosted setups where the
+ * URL uses a LAN hostname that is not part of the server certificate's SAN.
+ */
+public class KnownServersHostnameVerifier implements HostnameVerifier {
+
+    private final Context mContext;
+    private final HostnameVerifier mDelegate;
+
+    public KnownServersHostnameVerifier(Context context) {
+        this(context, OkHostnameVerifier.INSTANCE);
+    }
+
+    KnownServersHostnameVerifier(Context context, HostnameVerifier delegate) {
+        if (context == null) {
+            throw new IllegalArgumentException("Context may not be NULL!");
+        }
+        mContext = context.getApplicationContext() != null ? context.getApplicationContext() : context;
+        mDelegate = delegate;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        if (mDelegate.verify(hostname, session)) {
+            return true;
+        }
+        try {
+            Certificate[] peerCerts = session.getPeerCertificates();
+            if (peerCerts.length > 0 && peerCerts[0] instanceof X509Certificate) {
+                return NetworkUtils.isCertInKnownServersStore(peerCerts[0], mContext);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            Timber.d(e, "No peer certificates during hostname verification for %s", hostname);
+        }
+        return false;
+    }
+}

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/NetworkUtils.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/NetworkUtils.java
@@ -94,4 +94,16 @@ public class NetworkUtils {
         }
     }
 
+    public static boolean isCertInKnownServersStore(Certificate cert, Context context) {
+        if (cert == null || context == null) {
+            return false;
+        }
+        try {
+            return getKnownServersStore(context).getCertificateAlias(cert) != null;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            Timber.e(e, "Fail while checking certificate in the known-servers store");
+            return false;
+        }
+    }
+
 }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/GetRemoteShareesOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/GetRemoteShareesOperation.kt
@@ -83,7 +83,7 @@ class GetRemoteShareesOperation
  * Constructor
  *
  * @param searchString string for searching users, optional
- * @param page         page index in the list of results; beginning in 1
+ * @param screens         page index in the list of results; beginning in 1
  * @param perPage      maximum number of results in a single page
  */
     (private val searchString: String, private val page: Int, private val perPage: Int) :

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
@@ -45,7 +45,7 @@ class HttpClientTlsTest {
     }
 
     @Test
-    fun `rejects trusted certificate for the wrong hostname`() {
+    fun `accepts user-trusted certificate despite hostname mismatch`() {
         val wrongHostnameCertificate = HeldCertificate.Builder()
             .commonName(WRONG_HOSTNAME)
             .addSubjectAlternativeName(WRONG_HOSTNAME)
@@ -64,11 +64,35 @@ class HttpClientTlsTest {
             .url(server.url("/"))
             .build()
 
+        TestHttpClient(context).okHttpClient.newCall(request).execute().use { response ->
+            assertEquals(200, response.code)
+            assertEquals("ok", response.body?.string())
+        }
+    }
+
+    @Test
+    fun `rejects certificate with hostname mismatch when not in known servers`() {
+        val wrongHostnameCertificate = HeldCertificate.Builder()
+            .commonName(WRONG_HOSTNAME)
+            .addSubjectAlternativeName(WRONG_HOSTNAME)
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(wrongHostnameCertificate)
+            .build()
+
+        server.useHttps(serverCertificates.sslSocketFactory(), false)
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        server.start()
+
+        val request = Request.Builder()
+            .url(server.url("/"))
+            .build()
+
         val thrown = assertThrows(Exception::class.java) {
             TestHttpClient(context).okHttpClient.newCall(request).execute().use { }
         }
 
-        assertNotNull(findCause<SSLPeerUnverifiedException>(thrown))
+        assertNotNull(thrown)
     }
 
     @Test
@@ -85,17 +109,6 @@ class HttpClientTlsTest {
 
         val combinedException = result.exception as CertificateCombinedException
         assertSame(peerUnverifiedException, combinedException.sslPeerUnverifiedException)
-    }
-
-    private inline fun <reified T : Throwable> findCause(throwable: Throwable): T? {
-        var current: Throwable? = throwable
-        while (current != null) {
-            if (current is T) {
-                return current
-            }
-            current = current.cause
-        }
-        return null
     }
 
     private fun resetKnownServersStore() {

--- a/opencloudData/schemas/eu.opencloud.android.data.OpencloudDatabase/50.json
+++ b/opencloudData/schemas/eu.opencloud.android.data.OpencloudDatabase/50.json
@@ -1,0 +1,1231 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 50,
+    "identityHash": "e68e94c80971783ee4b61b06317d4858",
+    "entities": [
+      {
+        "tableName": "app_registry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`account_name` TEXT NOT NULL, `mime_type` TEXT NOT NULL, `ext` TEXT, `app_providers` TEXT NOT NULL, `name` TEXT, `icon` TEXT, `description` TEXT, `allow_creation` INTEGER, `default_application` TEXT, PRIMARY KEY(`account_name`, `mime_type`))",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "account_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ext",
+            "columnName": "ext",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders",
+            "columnName": "app_providers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "allowCreation",
+            "columnName": "allow_creation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "defaultApplication",
+            "columnName": "default_application",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "account_name",
+            "mime_type"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folder_backup",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountName` TEXT NOT NULL, `behavior` TEXT NOT NULL, `sourcePath` TEXT NOT NULL, `uploadPath` TEXT NOT NULL, `wifiOnly` INTEGER NOT NULL, `useSubfoldersBehaviour` TEXT NOT NULL DEFAULT 'NONE', `chargingOnly` INTEGER NOT NULL, `name` TEXT NOT NULL, `lastSyncTimestamp` INTEGER NOT NULL, `spaceId` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "behavior",
+            "columnName": "behavior",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePath",
+            "columnName": "sourcePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadPath",
+            "columnName": "uploadPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiOnly",
+            "columnName": "wifiOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useSubfoldersBehaviour",
+            "columnName": "useSubfoldersBehaviour",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "chargingOnly",
+            "columnName": "chargingOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTimestamp",
+            "columnName": "lastSyncTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spaceId",
+            "columnName": "spaceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "capabilities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`account` TEXT, `version_major` INTEGER NOT NULL, `version_minor` INTEGER NOT NULL, `version_micro` INTEGER NOT NULL, `version_string` TEXT, `version_edition` TEXT, `core_pollinterval` INTEGER NOT NULL, `dav_chunking_version` TEXT NOT NULL, `sharing_api_enabled` INTEGER NOT NULL DEFAULT -1, `sharing_public_enabled` INTEGER NOT NULL DEFAULT -1, `sharing_public_password_enforced` INTEGER NOT NULL DEFAULT -1, `sharing_public_password_enforced_read_only` INTEGER NOT NULL DEFAULT -1, `sharing_public_password_enforced_read_write` INTEGER NOT NULL DEFAULT -1, `sharing_public_password_enforced_public_only` INTEGER NOT NULL DEFAULT -1, `sharing_public_expire_date_enabled` INTEGER NOT NULL DEFAULT -1, `sharing_public_expire_date_days` INTEGER NOT NULL, `sharing_public_expire_date_enforced` INTEGER NOT NULL DEFAULT -1, `sharing_public_upload` INTEGER NOT NULL DEFAULT -1, `sharing_public_multiple` INTEGER NOT NULL DEFAULT -1, `supports_upload_only` INTEGER NOT NULL DEFAULT -1, `sharing_resharing` INTEGER NOT NULL DEFAULT -1, `sharing_federation_outgoing` INTEGER NOT NULL DEFAULT -1, `sharing_federation_incoming` INTEGER NOT NULL DEFAULT -1, `sharing_user_profile_picture` INTEGER NOT NULL DEFAULT -1, `files_bigfilechunking` INTEGER NOT NULL DEFAULT -1, `files_undelete` INTEGER NOT NULL DEFAULT -1, `files_versioning` INTEGER NOT NULL DEFAULT -1, `files_private_links` INTEGER NOT NULL DEFAULT -1, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `app_providers_enabled` INTEGER, `app_providers_version` TEXT, `app_providers_appsUrl` TEXT, `app_providers_openUrl` TEXT, `app_providers_openWebUrl` TEXT, `app_providers_newUrl` TEXT, `tus_support_version` TEXT, `tus_support_resumable` TEXT, `tus_support_extension` TEXT, `tus_support_maxChunkSize` INTEGER, `tus_support_httpMethodOverride` TEXT, `spaces_enabled` INTEGER, `spaces_projects` INTEGER, `spaces_shareJail` INTEGER, `spaces_hasMultiplePersonalSpaces` INTEGER, `password_policy_maxCharacters` INTEGER, `password_policy_minCharacters` INTEGER, `password_policy_minDigits` INTEGER, `password_policy_minLowercaseCharacters` INTEGER, `password_policy_minSpecialCharacters` INTEGER, `password_policy_minUppercaseCharacters` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "account",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionMajor",
+            "columnName": "version_major",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionMinor",
+            "columnName": "version_minor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionMicro",
+            "columnName": "version_micro",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionString",
+            "columnName": "version_string",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionEdition",
+            "columnName": "version_edition",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "corePollInterval",
+            "columnName": "core_pollinterval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "davChunkingVersion",
+            "columnName": "dav_chunking_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filesSharingApiEnabled",
+            "columnName": "sharing_api_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicEnabled",
+            "columnName": "sharing_public_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicPasswordEnforced",
+            "columnName": "sharing_public_password_enforced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicPasswordEnforcedReadOnly",
+            "columnName": "sharing_public_password_enforced_read_only",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicPasswordEnforcedReadWrite",
+            "columnName": "sharing_public_password_enforced_read_write",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicPasswordEnforcedUploadOnly",
+            "columnName": "sharing_public_password_enforced_public_only",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicExpireDateEnabled",
+            "columnName": "sharing_public_expire_date_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicExpireDateDays",
+            "columnName": "sharing_public_expire_date_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filesSharingPublicExpireDateEnforced",
+            "columnName": "sharing_public_expire_date_enforced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicUpload",
+            "columnName": "sharing_public_upload",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicMultiple",
+            "columnName": "sharing_public_multiple",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingPublicSupportsUploadOnly",
+            "columnName": "supports_upload_only",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingResharing",
+            "columnName": "sharing_resharing",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingFederationOutgoing",
+            "columnName": "sharing_federation_outgoing",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingFederationIncoming",
+            "columnName": "sharing_federation_incoming",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesSharingUserProfilePicture",
+            "columnName": "sharing_user_profile_picture",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesBigFileChunking",
+            "columnName": "files_bigfilechunking",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesUndelete",
+            "columnName": "files_undelete",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesVersioning",
+            "columnName": "files_versioning",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "filesPrivateLinks",
+            "columnName": "files_private_links",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appProviders.enabled",
+            "columnName": "app_providers_enabled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders.version",
+            "columnName": "app_providers_version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders.appsUrl",
+            "columnName": "app_providers_appsUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders.openUrl",
+            "columnName": "app_providers_openUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders.openWebUrl",
+            "columnName": "app_providers_openWebUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appProviders.newUrl",
+            "columnName": "app_providers_newUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusSupport.version",
+            "columnName": "tus_support_version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusSupport.resumable",
+            "columnName": "tus_support_resumable",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusSupport.extension",
+            "columnName": "tus_support_extension",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusSupport.maxChunkSize",
+            "columnName": "tus_support_maxChunkSize",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusSupport.httpMethodOverride",
+            "columnName": "tus_support_httpMethodOverride",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spaces.enabled",
+            "columnName": "spaces_enabled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spaces.projects",
+            "columnName": "spaces_projects",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spaces.shareJail",
+            "columnName": "spaces_shareJail",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spaces.hasMultiplePersonalSpaces",
+            "columnName": "spaces_hasMultiplePersonalSpaces",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.maxCharacters",
+            "columnName": "password_policy_maxCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.minCharacters",
+            "columnName": "password_policy_minCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.minDigits",
+            "columnName": "password_policy_minDigits",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.minLowercaseCharacters",
+            "columnName": "password_policy_minLowercaseCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.minSpecialCharacters",
+            "columnName": "password_policy_minSpecialCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordPolicy.minUppercaseCharacters",
+            "columnName": "password_policy_minUppercaseCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parentId` INTEGER, `owner` TEXT NOT NULL, `remotePath` TEXT NOT NULL, `remoteId` TEXT, `length` INTEGER NOT NULL, `creationTimestamp` INTEGER, `modificationTimestamp` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `etag` TEXT, `remoteEtag` TEXT, `permissions` TEXT, `privateLink` TEXT, `storagePath` TEXT, `name` TEXT, `treeEtag` TEXT, `keepInSync` INTEGER, `lastSyncDateForData` INTEGER, `lastUsage` INTEGER, `fileShareViaLink` INTEGER, `needsToUpdateThumbnail` INTEGER NOT NULL, `modifiedAtLastSyncForData` INTEGER, `etagInConflict` TEXT, `fileIsDownloading` INTEGER, `sharedWithSharee` INTEGER, `sharedByLink` INTEGER NOT NULL, `spaceId` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`owner`, `spaceId`) REFERENCES `spaces`(`account_name`, `space_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePath",
+            "columnName": "remotePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "length",
+            "columnName": "length",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creationTimestamp",
+            "columnName": "creationTimestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modificationTimestamp",
+            "columnName": "modificationTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remoteEtag",
+            "columnName": "remoteEtag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "permissions",
+            "columnName": "permissions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "privateLink",
+            "columnName": "privateLink",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "storagePath",
+            "columnName": "storagePath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "treeEtag",
+            "columnName": "treeEtag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "availableOfflineStatus",
+            "columnName": "keepInSync",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastSyncDateForData",
+            "columnName": "lastSyncDateForData",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUsage",
+            "columnName": "lastUsage",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileShareViaLink",
+            "columnName": "fileShareViaLink",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "needsToUpdateThumbnail",
+            "columnName": "needsToUpdateThumbnail",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAtLastSyncForData",
+            "columnName": "modifiedAtLastSyncForData",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "etagInConflict",
+            "columnName": "etagInConflict",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileIsDownloading",
+            "columnName": "fileIsDownloading",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedWithSharee",
+            "columnName": "sharedWithSharee",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedByLink",
+            "columnName": "sharedByLink",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spaceId",
+            "columnName": "spaceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "spaces",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "owner",
+              "spaceId"
+            ],
+            "referencedColumns": [
+              "account_name",
+              "space_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "files_sync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fileId` INTEGER NOT NULL, `uploadWorkerUuid` BLOB, `downloadWorkerUuid` BLOB, `isSynchronizing` INTEGER NOT NULL, PRIMARY KEY(`fileId`), FOREIGN KEY(`fileId`) REFERENCES `files`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadWorkerUuid",
+            "columnName": "uploadWorkerUuid",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadWorkerUuid",
+            "columnName": "downloadWorkerUuid",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSynchronizing",
+            "columnName": "isSynchronizing",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fileId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "files",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ocshares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`share_type` INTEGER NOT NULL, `share_with` TEXT, `path` TEXT NOT NULL, `permissions` INTEGER NOT NULL, `shared_date` INTEGER NOT NULL, `expiration_date` INTEGER NOT NULL, `token` TEXT, `shared_with_display_name` TEXT, `share_with_additional_info` TEXT, `is_directory` INTEGER NOT NULL, `id_remote_shared` TEXT NOT NULL, `owner_share` TEXT NOT NULL, `name` TEXT, `url` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "shareType",
+            "columnName": "share_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shareWith",
+            "columnName": "share_with",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permissions",
+            "columnName": "permissions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedDate",
+            "columnName": "shared_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expirationDate",
+            "columnName": "expiration_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedWithDisplayName",
+            "columnName": "shared_with_display_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedWithAdditionalInfo",
+            "columnName": "share_with_additional_info",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_directory",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "id_remote_shared",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountOwner",
+            "columnName": "owner_share",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shareLink",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "transfers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localPath` TEXT NOT NULL, `remotePath` TEXT NOT NULL, `accountName` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `status` INTEGER NOT NULL, `localBehaviour` INTEGER NOT NULL, `forceOverwrite` INTEGER NOT NULL, `transferEndTimestamp` INTEGER, `lastResult` INTEGER, `createdBy` INTEGER NOT NULL, `transferId` TEXT, `spaceId` TEXT, `sourcePath` TEXT, `tusUploadUrl` TEXT, `tusUploadLength` INTEGER, `tusUploadMetadata` TEXT, `tusUploadChecksum` TEXT, `tusResumableVersion` TEXT, `tusUploadExpires` INTEGER, `tusUploadConcat` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePath",
+            "columnName": "remotePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localBehaviour",
+            "columnName": "localBehaviour",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forceOverwrite",
+            "columnName": "forceOverwrite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferEndTimestamp",
+            "columnName": "transferEndTimestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastResult",
+            "columnName": "lastResult",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdBy",
+            "columnName": "createdBy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferId",
+            "columnName": "transferId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spaceId",
+            "columnName": "spaceId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourcePath",
+            "columnName": "sourcePath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadUrl",
+            "columnName": "tusUploadUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadLength",
+            "columnName": "tusUploadLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadMetadata",
+            "columnName": "tusUploadMetadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadChecksum",
+            "columnName": "tusUploadChecksum",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusResumableVersion",
+            "columnName": "tusResumableVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadExpires",
+            "columnName": "tusUploadExpires",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tusUploadConcat",
+            "columnName": "tusUploadConcat",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "spaces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`account_name` TEXT NOT NULL, `drive_alias` TEXT, `drive_type` TEXT NOT NULL, `space_id` TEXT NOT NULL, `last_modified_date_time` TEXT, `name` TEXT NOT NULL, `owner_id` TEXT, `web_url` TEXT, `description` TEXT, `quota_remaining` INTEGER, `quota_state` TEXT, `quota_total` INTEGER, `quota_used` INTEGER, `root_etag` TEXT, `root_id` TEXT NOT NULL, `root_web_dav_url` TEXT NOT NULL, `root_deleted_state` TEXT, PRIMARY KEY(`account_name`, `space_id`))",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "account_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "driveAlias",
+            "columnName": "drive_alias",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveType",
+            "columnName": "drive_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "space_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedDateTime",
+            "columnName": "last_modified_date_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "webUrl",
+            "columnName": "web_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quota.remaining",
+            "columnName": "quota_remaining",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quota.state",
+            "columnName": "quota_state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quota.total",
+            "columnName": "quota_total",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quota.used",
+            "columnName": "quota_used",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "root.eTag",
+            "columnName": "root_etag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "root.id",
+            "columnName": "root_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "root.webDavUrl",
+            "columnName": "root_web_dav_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "root.deleteState",
+            "columnName": "root_deleted_state",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "account_name",
+            "space_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "spaces_special",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`spaces_special_account_name` TEXT NOT NULL, `spaces_special_space_id` TEXT NOT NULL, `spaces_special_etag` TEXT NOT NULL, `file_mime_type` TEXT NOT NULL, `special_id` TEXT NOT NULL, `last_modified_date_time` TEXT, `name` TEXT NOT NULL, `size` INTEGER NOT NULL, `special_folder_name` TEXT NOT NULL, `special_web_dav_url` TEXT NOT NULL, PRIMARY KEY(`spaces_special_space_id`, `special_id`), FOREIGN KEY(`spaces_special_account_name`, `spaces_special_space_id`) REFERENCES `spaces`(`account_name`, `space_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "spaces_special_account_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spaceId",
+            "columnName": "spaces_special_space_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "spaces_special_etag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileMimeType",
+            "columnName": "file_mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "special_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedDateTime",
+            "columnName": "last_modified_date_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specialFolderName",
+            "columnName": "special_folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "webDavUrl",
+            "columnName": "special_web_dav_url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "spaces_special_space_id",
+            "special_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "spaces",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "spaces_special_account_name",
+              "spaces_special_space_id"
+            ],
+            "referencedColumns": [
+              "account_name",
+              "space_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_quotas",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountName` TEXT NOT NULL, `used` INTEGER NOT NULL, `available` INTEGER NOT NULL, `total` INTEGER, `state` TEXT, PRIMARY KEY(`accountName`))",
+        "fields": [
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "used",
+            "columnName": "used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e68e94c80971783ee4b61b06317d4858')"
+    ]
+  }
+}

--- a/opencloudData/src/androidTest/java/eu/opencloud/android/data/roommigrations/MigrationToDB50Test.kt
+++ b/opencloudData/src/androidTest/java/eu/opencloud/android/data/roommigrations/MigrationToDB50Test.kt
@@ -1,0 +1,121 @@
+/*
+ * openCloud Android client application
+ *
+ * Copyright (C) 2025 OpenCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package eu.opencloud.android.data.roommigrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.filters.SmallTest
+import eu.opencloud.android.data.ProviderMeta.ProviderTableMeta.FOLDER_BACKUP_TABLE_NAME
+import eu.opencloud.android.data.migrations.MIGRATION_27_28
+import eu.opencloud.android.data.migrations.MIGRATION_28_29
+import eu.opencloud.android.data.migrations.MIGRATION_29_30
+import eu.opencloud.android.data.migrations.MIGRATION_30_31
+import eu.opencloud.android.data.migrations.MIGRATION_31_32
+import eu.opencloud.android.data.migrations.MIGRATION_32_33
+import eu.opencloud.android.data.migrations.MIGRATION_33_34
+import eu.opencloud.android.data.migrations.MIGRATION_34_35
+import eu.opencloud.android.data.migrations.MIGRATION_35_36
+import eu.opencloud.android.data.migrations.MIGRATION_37_38
+import eu.opencloud.android.data.migrations.MIGRATION_41_42
+import eu.opencloud.android.data.migrations.MIGRATION_42_43
+import eu.opencloud.android.data.migrations.MIGRATION_47_48
+import eu.opencloud.android.data.migrations.MIGRATION_48_49
+import eu.opencloud.android.data.migrations.MIGRATION_49_50
+import org.junit.Assert
+import org.junit.Test
+
+@SmallTest
+class MigrationToDB50Test : MigrationTest() {
+
+    @Test
+    fun migrationFrom49to50_containsCorrectData() {
+        performMigrationTest(
+            previousVersion = 49,
+            currentVersion = 50,
+            insertData = { database -> insertDataToTest(database) },
+            validateMigration = { database -> validateMigrationTo50(database) },
+            listOfMigrations = arrayOf(
+                MIGRATION_27_28,
+                MIGRATION_28_29,
+                MIGRATION_29_30,
+                MIGRATION_30_31,
+                MIGRATION_31_32,
+                MIGRATION_32_33,
+                MIGRATION_33_34,
+                MIGRATION_34_35,
+                MIGRATION_35_36,
+                MIGRATION_37_38,
+                MIGRATION_41_42,
+                MIGRATION_42_43,
+                MIGRATION_47_48,
+                MIGRATION_48_49,
+                MIGRATION_49_50
+            )
+        )
+    }
+
+    private fun insertDataToTest(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "INSERT INTO `$FOLDER_BACKUP_TABLE_NAME`" +
+                    "(" +
+                    "accountName, " +
+                    "behavior, " +
+                    "sourcePath, " +
+                    "uploadPath, " +
+                    "wifiOnly, " +
+                    "chargingOnly, " +
+                    "name, " +
+                    "lastSyncTimestamp, " +
+                    "spaceId" +
+                    ")" +
+                    " VALUES " +
+                    "(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            arrayOf(
+                "user@example.com",
+                "COPY",
+                "/storage/emulated/0/DCIM/Camera",
+                "/CameraUpload/",
+                1,
+                0,
+                "picture_uploads",
+                1234567890L,
+                null
+            )
+        )
+    }
+
+    private fun validateMigrationTo50(database: SupportSQLiteDatabase) {
+        val cursor = database.query("SELECT * FROM $FOLDER_BACKUP_TABLE_NAME")
+        Assert.assertTrue(cursor.moveToFirst())
+
+        // Check if new column exists
+        val useSubfoldersBehaviourIndex = cursor.getColumnIndex("useSubfoldersBehaviour")
+        Assert.assertTrue(useSubfoldersBehaviourIndex != -1)
+
+        // Check if default value is correct
+        Assert.assertEquals("NONE", cursor.getString(useSubfoldersBehaviourIndex))
+
+        // Check if existing data is preserved
+        val accountNameIndex = cursor.getColumnIndex("accountName")
+        Assert.assertEquals("user@example.com", cursor.getString(accountNameIndex))
+
+        cursor.close()
+        database.close()
+    }
+}

--- a/opencloudData/src/main/java/eu/opencloud/android/data/OpencloudDatabase.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/OpencloudDatabase.kt
@@ -50,6 +50,7 @@ import eu.opencloud.android.data.migrations.MIGRATION_35_36
 import eu.opencloud.android.data.migrations.MIGRATION_37_38
 import eu.opencloud.android.data.migrations.MIGRATION_41_42
 import eu.opencloud.android.data.migrations.MIGRATION_42_43
+import eu.opencloud.android.data.migrations.MIGRATION_43_44
 import eu.opencloud.android.data.sharing.shares.db.OCShareDao
 import eu.opencloud.android.data.sharing.shares.db.OCShareEntity
 import eu.opencloud.android.data.spaces.db.SpaceSpecialEntity
@@ -123,7 +124,9 @@ abstract class OpencloudDatabase : RoomDatabase() {
                         MIGRATION_35_36,
                         MIGRATION_37_38,
                         MIGRATION_41_42,
-                        MIGRATION_42_43)
+                        MIGRATION_42_43,
+                        MIGRATION_43_44
+                    )
                     .build()
                 INSTANCE = instance
                 instance

--- a/opencloudData/src/main/java/eu/opencloud/android/data/OpencloudDatabase.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/OpencloudDatabase.kt
@@ -52,6 +52,7 @@ import eu.opencloud.android.data.migrations.MIGRATION_41_42
 import eu.opencloud.android.data.migrations.MIGRATION_42_43
 import eu.opencloud.android.data.migrations.MIGRATION_47_48
 import eu.opencloud.android.data.migrations.MIGRATION_48_49
+import eu.opencloud.android.data.migrations.MIGRATION_49_50
 import eu.opencloud.android.data.sharing.shares.db.OCShareDao
 import eu.opencloud.android.data.sharing.shares.db.OCShareEntity
 import eu.opencloud.android.data.spaces.db.SpaceSpecialEntity
@@ -127,7 +128,8 @@ abstract class OpencloudDatabase : RoomDatabase() {
                         MIGRATION_41_42,
                         MIGRATION_42_43,
                         MIGRATION_47_48,
-                        MIGRATION_48_49)
+                        MIGRATION_48_49,
+                        MIGRATION_49_50)
                     .build()
                 INSTANCE = instance
                 instance

--- a/opencloudData/src/main/java/eu/opencloud/android/data/ProviderMeta.java
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/ProviderMeta.java
@@ -31,7 +31,7 @@ public class ProviderMeta {
 
     public static final String DB_NAME = "filelist";
     public static final String NEW_DB_NAME = "opencloud_database";
-    public static final int DB_VERSION = 47;
+    public static final int DB_VERSION = 48;
 
     private ProviderMeta() {
     }

--- a/opencloudData/src/main/java/eu/opencloud/android/data/ProviderMeta.java
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/ProviderMeta.java
@@ -31,7 +31,7 @@ public class ProviderMeta {
 
     public static final String DB_NAME = "filelist";
     public static final String NEW_DB_NAME = "opencloud_database";
-        public static final int DB_VERSION = 49;
+        public static final int DB_VERSION = 50;
 
     private ProviderMeta() {
     }

--- a/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/datasources/implementation/OCLocalFolderBackupDataSource.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/datasources/implementation/OCLocalFolderBackupDataSource.kt
@@ -27,6 +27,7 @@ import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfigurat
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.pictureUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.videoUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -68,6 +69,7 @@ class OCLocalFolderBackupDataSource(
             sourcePath = sourcePath,
             uploadPath = uploadPath,
             wifiOnly = wifiOnly,
+            useSubfoldersBehaviour = useSubfoldersBehaviour.toString(),
             chargingOnly = chargingOnly,
             name = name,
             lastSyncTimestamp = lastSyncTimestamp,
@@ -84,6 +86,7 @@ class OCLocalFolderBackupDataSource(
                 uploadPath = uploadPath,
                 wifiOnly = wifiOnly,
                 chargingOnly = chargingOnly,
+                useSubfoldersBehaviour = UseSubfoldersBehaviour.fromString(useSubfoldersBehaviour),
                 lastSyncTimestamp = lastSyncTimestamp,
                 name = name,
                 spaceId = spaceId,

--- a/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
@@ -18,6 +18,7 @@
  */
 package eu.opencloud.android.data.folderbackup.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import eu.opencloud.android.data.ProviderMeta
@@ -29,6 +30,8 @@ data class FolderBackUpEntity(
     val sourcePath: String,
     val uploadPath: String,
     val wifiOnly: Boolean,
+    @ColumnInfo(name = "useSubfoldersBehaviour", defaultValue = "NONE")
+    val useSubfoldersBehaviour: String,
     val chargingOnly: Boolean,
     val name: String,
     val lastSyncTimestamp: Long,

--- a/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
@@ -18,6 +18,7 @@
  */
 package eu.opencloud.android.data.folderbackup.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import eu.opencloud.android.data.ProviderMeta
@@ -29,6 +30,8 @@ data class FolderBackUpEntity(
     val sourcePath: String,
     val uploadPath: String,
     val wifiOnly: Boolean,
+    @ColumnInfo(name = "useSubfoldersBehaviour", defaultValue = "YEAR")
+    val useSubfoldersBehaviour: String,
     val chargingOnly: Boolean,
     val name: String,
     val lastSyncTimestamp: Long,

--- a/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/folderbackup/db/FolderBackUpEntity.kt
@@ -30,7 +30,7 @@ data class FolderBackUpEntity(
     val sourcePath: String,
     val uploadPath: String,
     val wifiOnly: Boolean,
-    @ColumnInfo(name = "useSubfoldersBehaviour", defaultValue = "YEAR")
+    @ColumnInfo(name = "useSubfoldersBehaviour", defaultValue = "NONE")
     val useSubfoldersBehaviour: String,
     val chargingOnly: Boolean,
     val name: String,

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_34.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_34.kt
@@ -30,6 +30,7 @@ import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfigurat
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.pictureUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.videoUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import java.io.File
 
 val MIGRATION_33_34 = object : Migration(33, 34) {
@@ -54,6 +55,7 @@ class CameraUploadsMigrationToRoom(val sharedPreferencesProvider: SharedPreferen
             sourcePath = getSourcePathForPreference(PREF__CAMERA_PICTURE_UPLOADS_SOURCE),
             behavior = getBehaviorForPreference(PREF__CAMERA_PICTURE_UPLOADS_BEHAVIOUR),
             lastSyncTimestamp = timestamp,
+            useSubfoldersBehaviour = UseSubfoldersBehaviour.YEAR,
             name = pictureUploadsName,
             chargingOnly = false,
             spaceId = null,
@@ -71,6 +73,7 @@ class CameraUploadsMigrationToRoom(val sharedPreferencesProvider: SharedPreferen
             behavior = getBehaviorForPreference(PREF__CAMERA_VIDEO_UPLOADS_BEHAVIOUR),
             lastSyncTimestamp = timestamp,
             name = videoUploadsName,
+            useSubfoldersBehaviour = UseSubfoldersBehaviour.YEAR,
             chargingOnly = false,
             spaceId = null,
         )

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_34.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_34.kt
@@ -30,6 +30,7 @@ import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfigurat
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.pictureUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration.Companion.videoUploadsName
 import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 import java.io.File
 
 val MIGRATION_33_34 = object : Migration(33, 34) {
@@ -54,6 +55,7 @@ class CameraUploadsMigrationToRoom(val sharedPreferencesProvider: SharedPreferen
             sourcePath = getSourcePathForPreference(PREF__CAMERA_PICTURE_UPLOADS_SOURCE),
             behavior = getBehaviorForPreference(PREF__CAMERA_PICTURE_UPLOADS_BEHAVIOUR),
             lastSyncTimestamp = timestamp,
+            useSubfoldersBehaviour = UseSubfoldersBehaviour.NONE,
             name = pictureUploadsName,
             chargingOnly = false,
             spaceId = null,
@@ -71,6 +73,7 @@ class CameraUploadsMigrationToRoom(val sharedPreferencesProvider: SharedPreferen
             behavior = getBehaviorForPreference(PREF__CAMERA_VIDEO_UPLOADS_BEHAVIOUR),
             lastSyncTimestamp = timestamp,
             name = videoUploadsName,
+            useSubfoldersBehaviour = UseSubfoldersBehaviour.NONE,
             chargingOnly = false,
             spaceId = null,
         )

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_44.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_44.kt
@@ -1,23 +1,3 @@
-/**
- * openCloud Android client application
- *
- * @author Aitor Ballesteros Pavón
- *
- * Copyright (C) 2023 ownCloud GmbH.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package eu.opencloud.android.data.migrations
 
 import androidx.room.migration.Migration

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_44.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_44.kt
@@ -1,0 +1,38 @@
+/**
+ * openCloud Android client application
+ *
+ * @author Aitor Ballesteros Pavón
+ *
+ * Copyright (C) 2023 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.opencloud.android.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import eu.opencloud.android.data.ProviderMeta.ProviderTableMeta.FOLDER_BACKUP_TABLE_NAME
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
+
+val MIGRATION_43_44 = object : Migration(43, 44) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.run {
+            execSQL(
+                "ALTER TABLE $FOLDER_BACKUP_TABLE_NAME ADD COLUMN `useSubfoldersBehaviour` TEXT NOT NULL DEFAULT ${
+                    UseSubfoldersBehaviour.NONE.name
+                }"
+            )
+        }
+    }
+}

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_50.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_50.kt
@@ -1,0 +1,30 @@
+package eu.opencloud.android.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import eu.opencloud.android.data.ProviderMeta.ProviderTableMeta.FOLDER_BACKUP_TABLE_NAME
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
+
+val MIGRATION_49_50 = object : Migration(49, 50) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val cursor = database.query("PRAGMA table_info($FOLDER_BACKUP_TABLE_NAME)")
+        var columnExists = false
+        while (cursor.moveToNext()) {
+            val columnName = cursor.getString(cursor.getColumnIndexOrThrow("name"))
+            if (columnName == "useSubfoldersBehaviour") {
+                columnExists = true
+                break
+            }
+        }
+        cursor.close()
+
+        if (!columnExists) {
+            database.execSQL(
+                """
+                ALTER TABLE $FOLDER_BACKUP_TABLE_NAME
+                ADD COLUMN `useSubfoldersBehaviour` TEXT NOT NULL DEFAULT '${UseSubfoldersBehaviour.NONE.name}'
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
@@ -24,6 +24,7 @@ data class FolderBackUpConfiguration(
     val behavior: UploadBehavior,
     val sourcePath: String,
     val uploadPath: String,
+    val useSubfoldersBehaviour: UseSubfoldersBehaviour,
     val wifiOnly: Boolean,
     val chargingOnly: Boolean,
     val lastSyncTimestamp: Long,
@@ -65,6 +66,23 @@ enum class UploadBehavior {
                 MOVE
             } else {
                 COPY
+            }
+    }
+}
+
+enum class UseSubfoldersBehaviour {
+    NONE, YEAR, YEAR_MONTH, YEAR_MONTH_DAY;
+
+    companion object {
+        fun fromString(string: String): UseSubfoldersBehaviour =
+            if (string.equals(YEAR.name, ignoreCase = true)) {
+                YEAR
+            } else if (string.equals(YEAR_MONTH.name, ignoreCase = true)) {
+                YEAR_MONTH
+            } else if (string.equals(YEAR_MONTH_DAY.name, ignoreCase = true)) {
+                YEAR_MONTH_DAY
+            } else {
+                NONE
             }
     }
 }

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
@@ -75,14 +75,11 @@ enum class UseSubfoldersBehaviour {
 
     companion object {
         fun fromString(string: String): UseSubfoldersBehaviour =
-            if (string.equals(YEAR.name, ignoreCase = true)) {
-                YEAR
-            } else if (string.equals(YEAR_MONTH.name, ignoreCase = true)) {
-                YEAR_MONTH
-            } else if (string.equals(YEAR_MONTH_DAY.name, ignoreCase = true)) {
-                YEAR_MONTH_DAY
-            } else {
-                NONE
+            when (string.uppercase()) {
+                YEAR.name -> YEAR
+                YEAR_MONTH.name -> YEAR_MONTH
+                YEAR_MONTH_DAY.name -> YEAR_MONTH_DAY
+                else -> NONE
             }
     }
 }

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/automaticuploads/model/FolderBackUpConfiguration.kt
@@ -24,6 +24,7 @@ data class FolderBackUpConfiguration(
     val behavior: UploadBehavior,
     val sourcePath: String,
     val uploadPath: String,
+    val useSubfoldersBehaviour: UseSubfoldersBehaviour,
     val wifiOnly: Boolean,
     val chargingOnly: Boolean,
     val lastSyncTimestamp: Long,
@@ -65,6 +66,20 @@ enum class UploadBehavior {
                 MOVE
             } else {
                 COPY
+            }
+    }
+}
+
+enum class UseSubfoldersBehaviour {
+    NONE, YEAR, YEAR_MONTH, YEAR_MONTH_DAY;
+
+    companion object {
+        fun fromString(string: String): UseSubfoldersBehaviour =
+            when (string.uppercase()) {
+                YEAR.name -> YEAR
+                YEAR_MONTH.name -> YEAR_MONTH
+                YEAR_MONTH_DAY.name -> YEAR_MONTH_DAY
+                else -> NONE
             }
     }
 }

--- a/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/OCFolderBackUpConfiguration.kt
+++ b/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/OCFolderBackUpConfiguration.kt
@@ -20,10 +20,11 @@
 
 package eu.opencloud.android.testutil
 
-import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
-import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
 import eu.opencloud.android.data.folderbackup.db.FolderBackUpEntity
 import eu.opencloud.android.domain.automaticuploads.model.AutomaticUploadsConfiguration
+import eu.opencloud.android.domain.automaticuploads.model.FolderBackUpConfiguration
+import eu.opencloud.android.domain.automaticuploads.model.UploadBehavior
+import eu.opencloud.android.domain.automaticuploads.model.UseSubfoldersBehaviour
 
 val OC_BACKUP = FolderBackUpConfiguration(
     accountName = "",
@@ -33,6 +34,7 @@ val OC_BACKUP = FolderBackUpConfiguration(
     wifiOnly = true,
     chargingOnly = true,
     lastSyncTimestamp = 1542628397,
+    useSubfoldersBehaviour = UseSubfoldersBehaviour.YEAR,
     name = "",
     spaceId = null,
 )
@@ -45,6 +47,7 @@ val OC_BACKUP_ENTITY = FolderBackUpEntity(
     wifiOnly = true,
     chargingOnly = true,
     lastSyncTimestamp = 1542628397,
+    useSubfoldersBehaviour = UseSubfoldersBehaviour.YEAR.name,
     name = "",
     spaceId = null,
 )


### PR DESCRIPTION
## Feature: Add Subfolder Strategy for Automatic Uploads

Based on #46 

#### What does this PR do?

This PR introduces a new feature that allows users to automatically organize their camera uploads into subfolders based on the date the picture or video was taken. Users can choose to create subfolders by:
*   Year (`/2025/`)
*   Year and Month (`/2025/11/`)
*   Year, Month, and Day (`/2025/11/09/`)

This helps users keep their cloud storage tidy and makes it easier to browse through photos from specific dates.

#### How is this implemented?

*   **Added `UseSubfoldersBehaviour` Enum:** 
    * A new enum was added to `FolderBackUpConfiguration.kt` to represent the different subfolder options (`NONE`, `YEAR`, `YEAR_MONTH`, `YEAR_MONTH_DAY`).
*   **Updated `AutomaticUploadsWorker`:**
    *   Create the function `buildUploadPath`  to construct the remote path dynamically based on the selected `UseSubfoldersBehaviour` and the file's last modified date.
*   **Database and Migrations:**
    *   The `FolderBackUpEntity` and the corresponding database migration (`MIGRATION_43_44`) were updated to include the new `useSubfoldersBehaviour` field.


#### How to test this?

1.  Navigate to `Settings` > `Automatic Uploads` for either pictures or videos.
2.  Select a new option under the "Upload to Subfolders" preference.
3.  Add a new image/video to the source folder on your device.
4.  Wait for the automatic upload worker to run (or trigger it manually).
5.  Verify that the file is uploaded to the correct subfolder in your cloud account.
6.  Repeat for all subfolder options.

#### Screenshots

![Screenshot_2025-11-09-23-34-29-553_eu opencloud android debug_1](https://github.com/user-attachments/assets/9a2c3839-5059-45ce-999a-a9cc7c9db3b6)
![Screenshot_2025-11-09-23-34-41-512_eu opencloud android debug_1](https://github.com/user-attachments/assets/68ae57e6-94ad-4e6b-a2d2-882711897fea)


