### PR TITLE
fix: remove Authorization header for public clients in OAuth2 token exchange

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/AccountAuthenticator.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/AccountAuthenticator.java
@@ -345,7 +345,7 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
 
         String clientIdForRequest = null;
         String clientSecretForRequest = null;
-        String clientAuth = null;
+        String clientAuth;
 
         if (clientId == null) {
             Timber.d("Client Id not stored. Let's use the hardcoded one");
@@ -366,12 +366,12 @@ public class AccountAuthenticator extends AbstractAccountAuthenticator {
             // RFC 7636: Public clients (token_endpoint_auth_method: none) must not send Authorization header
             if (oidcServerConfigurationUseCaseResult.getDataOrNull() != null &&
                     oidcServerConfigurationUseCaseResult.getDataOrNull().isTokenEndpointAuthMethodNone()) {
-                clientAuth = null;
+                clientAuth = "";
                 clientIdForRequest = clientId;
             } else if (oidcServerConfigurationUseCaseResult.getDataOrNull() != null &&
                     oidcServerConfigurationUseCaseResult.getDataOrNull().isTokenEndpointAuthMethodSupportedClientSecretPost()) {
                 // For client_secret_post, credentials go in body, not Authorization header
-                clientAuth = null;
+                clientAuth = "";
                 clientIdForRequest = clientId;
                 clientSecretForRequest = clientSecret;
             } else {

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/oauth/TokenRequestRemoteOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/oauth/TokenRequestRemoteOperation.kt
@@ -54,8 +54,8 @@ class TokenRequestRemoteOperation(
 
             val postMethod = PostMethod(URL(tokenRequestParams.tokenEndpoint), requestBody)
 
-            tokenRequestParams.clientAuth?.takeIf { it.isNotEmpty() }?.let {
-                postMethod.addRequestHeader(AUTHORIZATION_HEADER, it)
+            if (tokenRequestParams.clientAuth.isNotEmpty()) {
+                postMethod.addRequestHeader(AUTHORIZATION_HEADER, tokenRequestParams.clientAuth)
             }
 
             val status = client.executeHttpMethod(postMethod)

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/oauth/params/TokenRequestParams.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/oauth/params/TokenRequestParams.kt
@@ -30,7 +30,7 @@ import okhttp3.RequestBody
 
 sealed class TokenRequestParams(
     val tokenEndpoint: String,
-    val clientAuth: String?,
+    val clientAuth: String,
     val grantType: String,
     val scope: String,
     val clientId: String?,
@@ -40,7 +40,7 @@ sealed class TokenRequestParams(
 
     class Authorization(
         tokenEndpoint: String,
-        clientAuth: String?,
+        clientAuth: String,
         grantType: String,
         scope: String,
         clientId: String?,
@@ -65,7 +65,7 @@ sealed class TokenRequestParams(
 
     class RefreshToken(
         tokenEndpoint: String,
-        clientAuth: String?,
+        clientAuth: String,
         grantType: String,
         scope: String,
         clientId: String?,

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/authentication/oauth/model/TokenRequest.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/authentication/oauth/model/TokenRequest.kt
@@ -24,7 +24,7 @@ package eu.opencloud.android.domain.authentication.oauth.model
 sealed class TokenRequest(
     val baseUrl: String,
     val tokenEndpoint: String,
-    val clientAuth: String?,
+    val clientAuth: String,
     val grantType: String,
     val scope: String,
     val clientId: String?,
@@ -33,7 +33,7 @@ sealed class TokenRequest(
     class AccessToken(
         baseUrl: String,
         tokenEndpoint: String,
-        clientAuth: String?,
+        clientAuth: String,
         scope: String,
         clientId: String? = null,
         clientSecret: String? = null,
@@ -45,7 +45,7 @@ sealed class TokenRequest(
     class RefreshToken(
         baseUrl: String,
         tokenEndpoint: String,
-        clientAuth: String?,
+        clientAuth: String,
         scope: String,
         clientId: String? = null,
         clientSecret: String? = null,

--- a/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/oauth/TokenRequest.kt
+++ b/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/oauth/TokenRequest.kt
@@ -43,3 +43,25 @@ val OC_TOKEN_REQUEST_ACCESS = TokenRequest.AccessToken(
     redirectUri = OC_REDIRECT_URI,
     codeVerifier = "A high-entropy cryptographic random STRING using the unreserved characters"
 )
+
+/**
+ * Test fixtures for public PKCE clients (RFC 7636).
+ * Public clients MUST NOT send Authorization header during token exchange.
+ */
+val OC_TOKEN_REQUEST_REFRESH_PUBLIC_CLIENT = TokenRequest.RefreshToken(
+    baseUrl = OC_SECURE_BASE_URL,
+    tokenEndpoint = OC_TOKEN_ENDPOINT,
+    clientAuth = "", // Empty for public clients per RFC 7636
+    scope = OC_SCOPE,
+    refreshToken = OC_REFRESH_TOKEN
+)
+
+val OC_TOKEN_REQUEST_ACCESS_PUBLIC_CLIENT = TokenRequest.AccessToken(
+    baseUrl = OC_SECURE_BASE_URL,
+    tokenEndpoint = OC_TOKEN_ENDPOINT,
+    clientAuth = "", // Empty for public clients per RFC 7636
+    scope = OC_SCOPE,
+    authorizationCode = "4uth0r1z4t10nC0d3",
+    redirectUri = OC_REDIRECT_URI,
+    codeVerifier = "A high-entropy cryptographic random STRING using the unreserved characters"
+)


### PR DESCRIPTION
## Summary
Public OAuth2 clients using PKCE should not send Authorization headers during token exchange per RFC 7636. This was causing token refresh failures with external OIDC providers like Authelia and Zitadel.

## Changes
- Made `clientAuth` nullable in `TokenRequest` and `TokenRequestParams`
- Added conditional Authorization header logic in `TokenRequestRemoteOperation` (only adds header when `clientAuth` is non-null and non-empty)
- Added `isTokenEndpointAuthMethodNone()` helper method in `OIDCServerConfiguration` to detect public clients
- Updated `LoginActivity` to set `clientAuth = null` for public clients based on `token_endpoint_auth_method` from OIDC discovery
- Updated `AccountAuthenticator` refresh token flow with same logic for consistent behavior

## Testing
Tested with Authelia OIDC provider configured with `token_endpoint_auth_method: none`. Both initial token exchange and token refresh now work correctly without sending the incorrect Authorization header.

## RFC Compliance
This change ensures compliance with RFC 7636 (PKCE) and RFC 6749 (OAuth 2.0), which specify that public clients should only send form parameters (client_id, code, code_verifier, redirect_uri, grant_type) during token exchange, with no Authorization header.

Related to #55