### PR TITLE
fix: add groups scope to OAuth2 OpenID Connect configuration

### DIFF
--- a/opencloudApp/src/main/res/values/setup.xml
+++ b/opencloudApp/src/main/res/values/setup.xml
@@ -89,7 +89,7 @@
     <string name="oauth2_redirect_uri_scheme">oc</string>
     <string name="oauth2_redirect_uri_host">android.opencloud.eu</string>
     <string name="oauth2_redirect_uri_path"></string>
-    <string name="oauth2_openid_scope">openid offline_access email profile</string>
+    <string name="oauth2_openid_scope">openid offline_access email profile groups</string>
     <string name="oauth2_openid_prompt">select_account consent</string>
 
     <!-- values that should be provided by openCloud server -->


### PR DESCRIPTION
## Summary

Adds the `groups` scope to the OAuth2 OpenID Connect configuration to enable role-based access control (RBAC) with OIDC providers.

## Changes

- Added `groups` to `oauth2_openid_scope` in `opencloudApp/src/main/res/values/setup.xml`

## Context

The `groups` scope is a de facto standard across major OIDC providers (Authelia, Keycloak, Authentik, Azure AD, Okta). Without it, OIDC providers cannot return group membership claims in the UserInfo response, preventing applications from implementing proper authorization based on user roles.

This change is backward compatible - per the OIDC specification, providers ignore unsupported scopes, so the OAuth flow will continue to work with providers that don't support the groups scope.