### PR TITLE
fix: prevent FAB vector tint crash on API 34/35

### DIFF
--- a/opencloudApp/src/main/res/drawable/ic_action_create_dir.xml
+++ b/opencloudApp/src/main/res/drawable/ic_action_create_dir.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:fillColor="@android:color/white"
       android:pathData="M20,6h-8l-2,-2L4,4c-1.11,0 -1.99,0.89 -1.99,2L2,18c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2L22,8c0,-1.11 -0.89,-2 -2,-2zM19,14h-3v3h-2v-3h-3v-2h3L14,9h2v3h3v2z"/>

--- a/opencloudApp/src/main/res/drawable/ic_action_create_file.xml
+++ b/opencloudApp/src/main/res/drawable/ic_action_create_file.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
     <path
         android:fillColor="@android:color/white"
         android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,16h-3v3h-2v-3L8,16v-2h3v-3h2v3h3v2zM13,9L13,3.5L18.5,9L13,9z" />

--- a/opencloudApp/src/main/res/drawable/ic_action_open_shortcut.xml
+++ b/opencloudApp/src/main/res/drawable/ic_action_open_shortcut.xml
@@ -3,7 +3,6 @@
     android:height="128dp"
     android:viewportWidth="960"
     android:viewportHeight="960"
-    android:tint="?attr/colorControlNormal"
     android:autoMirrored="true">
   <path
       android:fillColor="@android:color/white"


### PR DESCRIPTION
FloatingActionButton inflates our action icons without a themed Context. With targetSdk 34/35 the ?attr/colorControlNormal tint in the vectors cannot resolve and the app crashes during Splash/FileDisplayActivity startup (see unresolved theme attribute warnings). Remove the theme-dependent tint from ic_action_create_dir.xml, ic_action_create_file.xml, ic_action_open_shortcut.xml and let FAB apply its own tint. No code changes; verified with assembleDebug.

(cherry picked from commit 652f8c463216ce6004f14f7d66b6f17803a89af7)