### PR TITLE
Fix migration 48 crash by adding missing transfer columns

### DIFF
--- a/opencloudData/src/androidTest/java/eu/opencloud/android/data/roommigrations/MigrationToDB48Test.kt
+++ b/opencloudData/src/androidTest/java/eu/opencloud/android/data/roommigrations/MigrationToDB48Test.kt
@@ -1,0 +1,125 @@
+/*
+ * openCloud Android client application
+ *
+ * Copyright (C) 2024 OpenCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package eu.opencloud.android.data.roommigrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.filters.SmallTest
+import eu.opencloud.android.data.ProviderMeta.ProviderTableMeta.TRANSFERS_TABLE_NAME
+import eu.opencloud.android.data.migrations.MIGRATION_27_28
+import eu.opencloud.android.data.migrations.MIGRATION_28_29
+import eu.opencloud.android.data.migrations.MIGRATION_29_30
+import eu.opencloud.android.data.migrations.MIGRATION_30_31
+import eu.opencloud.android.data.migrations.MIGRATION_31_32
+import eu.opencloud.android.data.migrations.MIGRATION_32_33
+import eu.opencloud.android.data.migrations.MIGRATION_33_34
+import eu.opencloud.android.data.migrations.MIGRATION_34_35
+import eu.opencloud.android.data.migrations.MIGRATION_35_36
+import eu.opencloud.android.data.migrations.MIGRATION_37_38
+import eu.opencloud.android.data.migrations.MIGRATION_41_42
+import eu.opencloud.android.data.migrations.MIGRATION_42_43
+import eu.opencloud.android.data.migrations.MIGRATION_47_48
+import org.junit.Assert
+import org.junit.Test
+
+@SmallTest
+class MigrationToDB48Test : MigrationTest() {
+
+    @Test
+    fun migrationFrom47to48_containsCorrectData() {
+        performMigrationTest(
+            previousVersion = 47,
+            currentVersion = 48,
+            insertData = { database -> insertDataToTest(database) },
+            validateMigration = { database -> validateMigrationTo48(database) },
+            listOfMigrations = arrayOf(
+                MIGRATION_27_28,
+                MIGRATION_28_29,
+                MIGRATION_29_30,
+                MIGRATION_30_31,
+                MIGRATION_31_32,
+                MIGRATION_32_33,
+                MIGRATION_33_34,
+                MIGRATION_34_35,
+                MIGRATION_35_36,
+                MIGRATION_37_38,
+                MIGRATION_41_42,
+                MIGRATION_42_43,
+                MIGRATION_47_48
+            )
+        )
+    }
+
+    private fun insertDataToTest(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "INSERT INTO `$TRANSFERS_TABLE_NAME`" +
+                    "(" +
+                    "localPath, " +
+                    "remotePath, " +
+                    "accountName, " +
+                    "fileSize, " +
+                    "status, " +
+                    "localBehaviour, " +
+                    "forceOverwrite, " +
+                    "createdBy" +
+                    ")" +
+                    " VALUES " +
+                    "(?, ?, ?, ?, ?, ?, ?, ?)",
+            arrayOf(
+                "/storage/emulated/0/test.txt",
+                "/test.txt",
+                "user@example.com",
+                1024,
+                0,
+                0,
+                0,
+                0
+            )
+        )
+    }
+
+    private fun validateMigrationTo48(database: SupportSQLiteDatabase) {
+        val cursor = database.query("SELECT * FROM $TRANSFERS_TABLE_NAME")
+        Assert.assertTrue(cursor.moveToFirst())
+
+        // Check if new columns exist
+        val tusUploadUrlIndex = cursor.getColumnIndex("tusUploadUrl")
+        val tusUploadLengthIndex = cursor.getColumnIndex("tusUploadLength")
+        val tusUploadMetadataIndex = cursor.getColumnIndex("tusUploadMetadata")
+        val tusUploadChecksumIndex = cursor.getColumnIndex("tusUploadChecksum")
+        val tusResumableVersionIndex = cursor.getColumnIndex("tusResumableVersion")
+        val tusUploadExpiresIndex = cursor.getColumnIndex("tusUploadExpires")
+        val tusUploadConcatIndex = cursor.getColumnIndex("tusUploadConcat")
+
+        Assert.assertTrue(tusUploadUrlIndex != -1)
+        Assert.assertTrue(tusUploadLengthIndex != -1)
+        Assert.assertTrue(tusUploadMetadataIndex != -1)
+        Assert.assertTrue(tusUploadChecksumIndex != -1)
+        Assert.assertTrue(tusResumableVersionIndex != -1)
+        Assert.assertTrue(tusUploadExpiresIndex != -1)
+        Assert.assertTrue(tusUploadConcatIndex != -1)
+
+        // Check if existing data is preserved
+        val localPathIndex = cursor.getColumnIndex("localPath")
+        Assert.assertEquals("/storage/emulated/0/test.txt", cursor.getString(localPathIndex))
+
+        cursor.close()
+        database.close()
+    }
+}

--- a/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_48.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/migrations/Migration_48.kt
@@ -26,5 +26,13 @@ val MIGRATION_47_48 = object : Migration(47, 48) {
             "ALTER TABLE ${ProviderTableMeta.CAPABILITIES_TABLE_NAME} " +
                 "ADD COLUMN `${ProviderTableMeta.CAPABILITIES_TUS_SUPPORT_HTTP_METHOD_OVERRIDE}` TEXT"
         )
+
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadUrl` TEXT")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadLength` INTEGER")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadMetadata` TEXT")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadChecksum` TEXT")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusResumableVersion` TEXT")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadExpires` INTEGER")
+        database.execSQL("ALTER TABLE ${ProviderTableMeta.TRANSFERS_TABLE_NAME} ADD COLUMN `tusUploadConcat` TEXT")
     }
 }


### PR DESCRIPTION
# Fix crash in Migration 48 due to missing transfer columns

## Description
This PR fixes a crash that occurred during the database migration from version 47 to 48.
The application was throwing an `IllegalStateException: Migration didn't properly handle: transfers` because the `transfers` table schema in the database did not match the `OCTransferEntity` definition.

Specifically, the following columns were missing in the migration but expected by the Entity:
- `tusUploadUrl`
- `tusUploadLength`
- `tusUploadMetadata`
- `tusUploadChecksum`
- `tusResumableVersion`
- `tusUploadExpires`
- `tusUploadConcat`

## Changes
- **`Migration_48.kt`**: Added the missing `ALTER TABLE` statements to add the TUS-related columns to the `transfers` table.
- **`MigrationToDB48Test.kt`**: Added a new instrumentation test to verify that the migration from version 47 to 48 completes successfully and that the new columns are correctly added while preserving existing data.

## Verification
- Created and ran `MigrationToDB48Test`.
- Verified that the test passes on API 36 emulator.

```
> Task :opencloudData:connectedDebugAndroidTest
Starting 1 tests on Medium_Phone_API_36.0(AVD) - 16
Finished 1 tests on Medium_Phone_API_36.0(AVD) - 16
BUILD SUCCESSFUL
```

## Related Issue
- Fixes crash reported during upgrade testing.
