### PR TITLE
Fix duplicate folders and improve image caching performance

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/thumbnails/ThumbnailsRequester.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/thumbnails/ThumbnailsRequester.kt
@@ -64,6 +64,7 @@ object ThumbnailsRequester : KoinComponent {
 
     private val thumbnailImageLoaders = ConcurrentHashMap<String, ImageLoader>()
     private val avatarImageLoaders = ConcurrentHashMap<String, ImageLoader>()
+    private val accountBaseUrls = ConcurrentHashMap<String, String>()
 
     private val sharedDiskCache: DiskCache by lazy {
         DiskCache.Builder()
@@ -86,11 +87,12 @@ object ThumbnailsRequester : KoinComponent {
     }
 
     fun getAvatarUri(account: Account): String {
-        val accountManager = AccountManager.get(appContext)
-        val baseUrl =
+        val baseUrl = accountBaseUrls.getOrPut(account.name) {
+            val accountManager = AccountManager.get(appContext)
             accountManager.getUserData(account, eu.opencloud.android.lib.common.accounts.AccountUtils.Constants.KEY_OC_BASE_URL)
                 ?.trimEnd('/')
                 .orEmpty()
+        }
         // ?u= disambiguates the Coil cache key per account; without it two accounts
         // on the same server share the same URL and collide in the shared disk/memory cache.
         return "$baseUrl/graph/v1.0/me/photo/\$value?u=${account.name.hashCode().toString(16)}"
@@ -106,10 +108,12 @@ object ThumbnailsRequester : KoinComponent {
         String.format(Locale.US, SPACE_SPECIAL_PREVIEW_URI, spaceSpecial.webDavUrl, 1024, 1024, spaceSpecial.eTag)
 
     private fun getPreviewUri(remotePath: String?, etag: String?, account: Account, width: Int, height: Int): String {
-        val accountManager = AccountManager.get(appContext)
-        val baseUrl = accountManager.getUserData(account, eu.opencloud.android.lib.common.accounts.AccountUtils.Constants.KEY_OC_BASE_URL)
-            ?.trimEnd('/')
-            .orEmpty()
+        val baseUrl = accountBaseUrls.getOrPut(account.name) {
+            val accountManager = AccountManager.get(appContext)
+            accountManager.getUserData(account, eu.opencloud.android.lib.common.accounts.AccountUtils.Constants.KEY_OC_BASE_URL)
+                ?.trimEnd('/')
+                .orEmpty()
+        }
         val path = if (remotePath?.startsWith("/") == true) remotePath else "/$remotePath"
         val encodedPath = Uri.encode(path, "/")
 
@@ -156,7 +160,9 @@ object ThumbnailsRequester : KoinComponent {
                 // must not run on the main thread.
                 clientManager.getClientForCoilThumbnails(account.name)
                     .okHttpClient.newBuilder()
-                    .addInterceptor(interceptor).build()
+                    .addInterceptor(interceptor)
+                    .addNetworkInterceptor(CoilCacheResponseInterceptor())
+                    .build()
             }
             .apply { if (preferencesProvider.getBoolean("enable_logging", false)) logger(DebugLogger()) }
             .memoryCache { sharedMemoryCache }
@@ -172,6 +178,7 @@ object ThumbnailsRequester : KoinComponent {
                 clientManager.getClientForCoilThumbnails(account.name)
                     .okHttpClient.newBuilder()
                     .addInterceptor(interceptor)
+                    .addNetworkInterceptor(CoilCacheResponseInterceptor())
                     .cache(avatarHttpCache)
                     .build()
             }
@@ -221,7 +228,13 @@ object ThumbnailsRequester : KoinComponent {
             requestHeaders.toHeaders().forEach { requestBuilder.addHeader(it.first, it.second) }
             val requestWithHeaders = requestBuilder.build()
 
-            var response = chain.proceed(requestWithHeaders)
+            return chain.proceed(requestWithHeaders)
+        }
+    }
+
+    private class CoilCacheResponseInterceptor : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val response = chain.proceed(chain.request())
 
             var builder = response.newBuilder()
             var changed = false
@@ -252,6 +265,5 @@ object ThumbnailsRequester : KoinComponent {
             }
             return response
         }
-
     }
 }

--- a/opencloudData/src/main/java/eu/opencloud/android/data/files/datasources/implementation/OCRemoteFileDataSource.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/files/datasources/implementation/OCRemoteFileDataSource.kt
@@ -218,7 +218,11 @@ class OCRemoteFileDataSource(
             OCFile(
                 owner = owner,
                 remoteId = remoteId,
-                remotePath = remotePath,
+                remotePath = if (isFolder && !remotePath.endsWith(OCFile.PATH_SEPARATOR)) {
+                    "$remotePath${OCFile.PATH_SEPARATOR}"
+                } else {
+                    remotePath
+                },
                 length = if (isFolder) {
                     size
                 } else {


### PR DESCRIPTION
First up, this PR fixes a bug where the app sometimes displays folders twice in the UI, leaving one completely empty and one behaving normally.

The issue comes down to how different WebDAV proxies handle trailing slashes. When the app creates a folder locally, it applies a trailing slash to the path. But when the backend returns listings during syncs, it sometimes provides the path without that trailing slash. Because the database looks for a strict string match, the lookup fails and the app inserts a duplicate clone. To solve this, I tweaked the toModel mapper in OCRemoteFileDataSource.kt. It now forcibly appends the path separator to any incoming folder path if it is missing. This guarantees a safe match and prevents duplicate empty clones.

Second, I did some performance optimization on the thumbnail rendering. Generating preview URLs used to hit the Android AccountManager synchronously to fetch the base URL for every single loaded image. Making all those IPC calls on the main thread during a fast scroll was creating noticeable stutter. I added a ConcurrentHashMap to the ThumbnailsRequester to cache these base URLs in memory, keeping the RecyclerView lists scrolling incredibly smoothly.
