### PR TITLE
Fix/tls trust known cert hostname

### DIFF
--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/http/HttpClient.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/http/HttpClient.java
@@ -28,6 +28,7 @@ import android.content.Context;
 
 import eu.opencloud.android.lib.common.http.logging.LogInterceptor;
 import eu.opencloud.android.lib.common.network.AdvancedX509TrustManager;
+import eu.opencloud.android.lib.common.network.KnownServersHostnameVerifier;
 import eu.opencloud.android.lib.common.network.NetworkUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -125,6 +126,7 @@ public class HttpClient {
                 .connectTimeout(HttpConstants.DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(false)
                 .sslSocketFactory(sslSocketFactory, trustManager)
+                .hostnameVerifier(new KnownServersHostnameVerifier(mContext))
                 .cookieJar(cookieJar)
                 .build();
     }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
@@ -1,5 +1,5 @@
 /* openCloud Android Library is available under MIT license
- *   Copyright (C) 2024 openCloud Contributors.
+ *   Copyright (C) 2026 openCloud Contributors.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/KnownServersHostnameVerifier.java
@@ -1,0 +1,79 @@
+/* openCloud Android Library is available under MIT license
+ *   Copyright (C) 2024 openCloud Contributors.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
+package eu.opencloud.android.lib.common.network;
+
+import android.content.Context;
+
+import okhttp3.internal.tls.OkHostnameVerifier;
+import timber.log.Timber;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+/**
+ * HostnameVerifier with a fallback for self-signed servers explicitly trusted by the user.
+ * <p>
+ * The RFC 2818/6125 check from {@link OkHostnameVerifier} is applied first. If it fails, the peer
+ * certificate is compared against the user-managed known-servers store. A match means the user
+ * already opted in to trust exactly this certificate (typically after accepting the untrusted-cert
+ * dialog), so the hostname mismatch is tolerated — this covers local self-hosted setups where the
+ * URL uses a LAN hostname that is not part of the server certificate's SAN.
+ */
+public class KnownServersHostnameVerifier implements HostnameVerifier {
+
+    private final Context mContext;
+    private final HostnameVerifier mDelegate;
+
+    public KnownServersHostnameVerifier(Context context) {
+        this(context, OkHostnameVerifier.INSTANCE);
+    }
+
+    KnownServersHostnameVerifier(Context context, HostnameVerifier delegate) {
+        if (context == null) {
+            throw new IllegalArgumentException("Context may not be NULL!");
+        }
+        mContext = context.getApplicationContext() != null ? context.getApplicationContext() : context;
+        mDelegate = delegate;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        if (mDelegate.verify(hostname, session)) {
+            return true;
+        }
+        try {
+            Certificate[] peerCerts = session.getPeerCertificates();
+            if (peerCerts.length > 0 && peerCerts[0] instanceof X509Certificate) {
+                return NetworkUtils.isCertInKnownServersStore(peerCerts[0], mContext);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            Timber.d(e, "No peer certificates during hostname verification for %s", hostname);
+        }
+        return false;
+    }
+}

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/NetworkUtils.java
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/NetworkUtils.java
@@ -94,4 +94,16 @@ public class NetworkUtils {
         }
     }
 
+    public static boolean isCertInKnownServersStore(Certificate cert, Context context) {
+        if (cert == null || context == null) {
+            return false;
+        }
+        try {
+            return getKnownServersStore(context).getCertificateAlias(cert) != null;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            Timber.e(e, "Fail while checking certificate in the known-servers store");
+            return false;
+        }
+    }
+
 }

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
@@ -111,17 +111,6 @@ class HttpClientTlsTest {
         assertSame(peerUnverifiedException, combinedException.sslPeerUnverifiedException)
     }
 
-    private inline fun <reified T : Throwable> findCause(throwable: Throwable): T? {
-        var current: Throwable? = throwable
-        while (current != null) {
-            if (current is T) {
-                return current
-            }
-            current = current.cause
-        }
-        return null
-    }
-
     private fun resetKnownServersStore() {
         context.deleteFile(KNOWN_SERVERS_STORE_FILE)
 

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/common/http/HttpClientTlsTest.kt
@@ -45,7 +45,7 @@ class HttpClientTlsTest {
     }
 
     @Test
-    fun `rejects trusted certificate for the wrong hostname`() {
+    fun `accepts user-trusted certificate despite hostname mismatch`() {
         val wrongHostnameCertificate = HeldCertificate.Builder()
             .commonName(WRONG_HOSTNAME)
             .addSubjectAlternativeName(WRONG_HOSTNAME)
@@ -64,11 +64,35 @@ class HttpClientTlsTest {
             .url(server.url("/"))
             .build()
 
+        TestHttpClient(context).okHttpClient.newCall(request).execute().use { response ->
+            assertEquals(200, response.code)
+            assertEquals("ok", response.body?.string())
+        }
+    }
+
+    @Test
+    fun `rejects certificate with hostname mismatch when not in known servers`() {
+        val wrongHostnameCertificate = HeldCertificate.Builder()
+            .commonName(WRONG_HOSTNAME)
+            .addSubjectAlternativeName(WRONG_HOSTNAME)
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(wrongHostnameCertificate)
+            .build()
+
+        server.useHttps(serverCertificates.sslSocketFactory(), false)
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+        server.start()
+
+        val request = Request.Builder()
+            .url(server.url("/"))
+            .build()
+
         val thrown = assertThrows(Exception::class.java) {
             TestHttpClient(context).okHttpClient.newCall(request).execute().use { }
         }
 
-        assertNotNull(findCause<SSLPeerUnverifiedException>(thrown))
+        assertNotNull(thrown)
     }
 
     @Test


### PR DESCRIPTION
Fixes the regression from 0c725147a, reported in #125.

The short version: 0c725147a (correctly) dropped the all-accepting HostnameVerifier that was effectively disabling hostname checks for every connection - a real MITM hole. Problem is, it also broke every self-hosted setup where the URL hostname doesn't match the cert's CN/SAN. Classic case from the issue: `https://truenas:30259` with a self-signed TrueNAS cert that's issued for `truenas.local` or an IP. On 1.2.0 this silently worked because the check was a no-op; on 1.2.1 it's a dead end with no way forward.

### Why it's a dead end, exactly

Walking the flow on 1.2.1 for the affected user:

1. URL entered, handshake starts. Cert is unknown -> `AdvancedX509TrustManager.checkServerTrusted()` throws `CertificateCombinedException`
2. First dialog ("Untrusted cert") shows up with Trust button, user clicks it, cert gets written to `knownServers.bks`
3. `onSavedCertificate()` retries the request
4. Second handshake: TrustManager is happy now. OkHttp's default HostnameVerifier kicks in and rejects `truenas` against the cert's SAN
5. `SSLPeerUnverifiedException` -> wrapped into the new `SSL_RECOVERABLE_PEER_UNVERIFIED` code path
6. Second dialog shows up. But `newInstanceForFullSslError` sees `sslPeerUnverifiedException != null` and sets `m509Certificate = null`, which in turn hides Cancel and relabels Trust as plain OK
7. User clicks OK, `mHandler == null` -> `onCancelCertificate()` -> login aborted

Reinstall doesn't help: cert stays in the store so the retry hits step 4 immediately without ever going through the trust dialog.

### The fix

New `KnownServersHostnameVerifier`. It runs OkHttp's default `OkHostnameVerifier` (RFC 2818/6125) first. If that passes, done. If it fails, it checks whether the peer cert is already in `knownServers.bks`. If yes, the hostname mismatch is accepted - the rationale being that the user has already actively opted into trusting exactly this certificate.

Per-scenario breakdown of what that does:

| Scenario | Before (1.2.1) | After |
|---|---|---|
| Valid public cert, correct hostname | OK | OK (fast path, no change) |
| Valid public cert, wrong hostname | Rejected | Still rejected (not in store) |
| Self-signed, hostname mismatch, user accepted once | Dead end | Works (this is the fix) |
| Self-signed, hostname mismatch, user hasn't accepted | Trust dialog -> dead end | Trust dialog -> works after trust |
| Random hostile cert we've never seen | Rejected | Still rejected |

Also added `NetworkUtils.isCertInKnownServersStore()` for the lookup.

### Security note

The 1.2.0 bypass was blanket - every TLS connection effectively had hostname verification disabled. This one is gated per-certificate on explicit user trust: someone pulling off a MITM needs both a copy of a cert the user has already accepted and network position. For self-hosted users the effective risk is equivalent to 1.2.0, but without the global bypass for all TLS traffic to regular servers.

### Dead code I left in place

The `sslPeerUnverifiedException` branch in `RemoteOperationResult` and the "hide Cancel + relabel OK" branch in `SslUntrustedCertDialog` are both unreachable in the normal flow now, because the HostnameVerifier handles the known-cert case before it ever bubbles up. I didn't rip them out in this PR - they still act as a safety net if a `SSLPeerUnverifiedException` ever comes through from a cert that isn't in the store (e.g. a misconfigured public server), so we'd still get a mapped result code and a sensible dialog instead of a generic network error. Happy to clean them up in a follow-up if you'd rather have lean code than defense in depth.

### Tests

`HttpClientTlsTest` updated to match the new contract:

- `accepts user-trusted certificate despite hostname mismatch` - the regression case, inverted from the previous "rejects" test
- `rejects certificate with hostname mismatch when not in known servers` - guards the security property
- `wraps hostname mismatch as certificate combined exception` - unchanged, still covers the fallback mapping

All three pass locally. Detekt and the app compile are also clean.

### Not tested by me

I don't have a TrueNAS box handy, so I didn't run the full login end-to-end on a real device against the affected setup. Confirmation from the reporter in #125 would be appreciated before merging.

Closes #125.
