### PR TITLE
Migrate ViewModel tests off deprecated coroutines-test 1.6 APIs

### DIFF
--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/DrawerViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/DrawerViewModelTest.kt
@@ -69,8 +69,6 @@ class DrawerViewModelTest : ViewModelTest() {
         getUserQuotasUseCase = mockk()
         localStorageProvider = mockk()
 
-        testCoroutineDispatcher.pauseDispatcher()
-
         drawerViewModel = DrawerViewModel(
             getStoredQuotaAsStreamUseCase = getStoredQuotaAsStreamUseCase,
             removeAccountUseCase = removeAccountUseCase,

--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/ViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/ViewModelTest.kt
@@ -28,7 +28,7 @@ import eu.opencloud.android.testutil.livedata.getEmittedValues
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -41,7 +41,7 @@ open class ViewModelTest {
     @JvmField
     val instantExecutorRule = InstantTaskExecutorRule()
 
-    val testCoroutineDispatcher = TestCoroutineDispatcher()
+    val testCoroutineDispatcher = StandardTestDispatcher()
     val coroutineDispatcherProvider: CoroutinesDispatcherProvider = CoroutinesDispatcherProvider(
         io = testCoroutineDispatcher,
         main = testCoroutineDispatcher,
@@ -51,7 +51,6 @@ open class ViewModelTest {
     @After
     open fun tearDown() {
         Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
 
         unmockkAll()
     }
@@ -61,7 +60,7 @@ open class ViewModelTest {
         liveData: LiveData<Event<UIResult<DomainModel>>>
     ) {
         val emittedValues = liveData.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(expectedValues, emittedValues)
     }

--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/authentication/AuthenticationViewModelTest.kt
@@ -129,8 +129,6 @@ class AuthenticationViewModelTest : ViewModelTest() {
         every { contextProvider.getBoolean(R.bool.enforce_secure_connection) } returns false
         every { contextProvider.getBoolean(R.bool.enforce_oidc) } returns false
 
-        testCoroutineDispatcher.pauseDispatcher()
-
         authenticationViewModel = AuthenticationViewModel(
             loginBasicAsyncUseCase = loginBasicAsyncUseCase,
             loginOAuthAsyncUseCase = loginOAuthAsyncUseCase,

--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/authentication/OAuthViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/authentication/OAuthViewModelTest.kt
@@ -87,8 +87,6 @@ class OAuthViewModelTest : ViewModelTest() {
         requestTokenUseCase = mockk()
         registerClientUseCase = mockk()
 
-        testCoroutineDispatcher.pauseDispatcher()
-
         oAuthViewModel = OAuthViewModel(
             getOIDCDiscoveryUseCase = getOIDCDiscoveryUseCase,
             requestTokenUseCase = requestTokenUseCase,

--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/capabilities/CapabilityViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/capabilities/CapabilityViewModelTest.kt
@@ -45,7 +45,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -68,7 +68,7 @@ class CapabilityViewModelTest {
 
     private val capabilitiesLiveData = MutableLiveData<OCCapability>()
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testCoroutineDispatcher = UnconfinedTestDispatcher()
     private val coroutineDispatcherProvider: CoroutinesDispatcherProvider = CoroutinesDispatcherProvider(
         io = testCoroutineDispatcher,
         main = testCoroutineDispatcher,
@@ -104,7 +104,6 @@ class CapabilityViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
 
         stopKoin()
         unmockkAll()

--- a/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/sharing/ShareViewModelTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/presentation/viewmodels/sharing/ShareViewModelTest.kt
@@ -51,7 +51,7 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -84,7 +84,7 @@ class ShareViewModelTest {
     private val sharesLiveData = MutableLiveData<List<OCShare>>()
     private val privateShareLiveData = MutableLiveData<OCShare>()
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testCoroutineDispatcher = StandardTestDispatcher()
     private val coroutineDispatcherProvider: CoroutinesDispatcherProvider = CoroutinesDispatcherProvider(
         io = testCoroutineDispatcher,
         main = testCoroutineDispatcher,
@@ -117,7 +117,6 @@ class ShareViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
 
         stopKoin()
         unmockkAll()
@@ -136,8 +135,6 @@ class ShareViewModelTest {
 
         every { getSharesAsLiveDataUseCase(any()) } returns sharesLiveData
         every { getShareAsLiveDataUseCase(any()) } returns privateShareLiveData
-
-        testCoroutineDispatcher.pauseDispatcher()
 
         shareViewModel = ShareViewModel(
             filePath,
@@ -193,7 +190,7 @@ class ShareViewModelTest {
         )
 
         val emittedValues = shareViewModel.privateShareCreationStatus.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(expectedValues, emittedValues)
 
@@ -209,7 +206,7 @@ class ShareViewModelTest {
         shareViewModel.refreshPrivateShare(OC_SHARE.remoteId)
 
         val emittedValues = shareViewModel.privateShare.getLastEmittedValue {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(Event(UIResult.Success(OC_SHARE)), emittedValues)
 
@@ -248,7 +245,7 @@ class ShareViewModelTest {
         )
 
         val emittedValues = shareViewModel.privateShareEditionStatus.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(expectedValues, emittedValues)
 
@@ -295,7 +292,7 @@ class ShareViewModelTest {
         )
 
         val emittedValues = shareViewModel.publicShareCreationStatus.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(expectedValues, emittedValues)
 
@@ -338,7 +335,7 @@ class ShareViewModelTest {
         )
 
         val emittedValues = shareViewModel.publicShareEditionStatus.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
         assertEquals(expectedValues, emittedValues)
 
@@ -378,7 +375,7 @@ class ShareViewModelTest {
         shareViewModel.deleteShare(remoteId = OC_SHARE.remoteId)
 
         val emittedValues = shareViewModel.shareDeletionStatus.getEmittedValues(expectedValues.size) {
-            testCoroutineDispatcher.resumeDispatcher()
+            testCoroutineDispatcher.scheduler.advanceUntilIdle()
         }
 
         assertEquals(expectedValues, emittedValues)


### PR DESCRIPTION
Fixes compile errors under kotlinx-coroutines 1.7+.