### PR TITLE
Handle empty drive lists during space refresh

### DIFF
--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/spaces/responses/SpacesResponse.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/spaces/responses/SpacesResponse.kt
@@ -54,7 +54,7 @@ data class OwnerResponse(
 data class QuotaResponse(
     val remaining: Long?,
     val state: String?,
-    val total: Long,
+    val total: Long?,
     val used: Long?,
 )
 

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/spaces/responses/SpacesResponseTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/spaces/responses/SpacesResponseTest.kt
@@ -1,0 +1,66 @@
+/* openCloud Android Library is available under MIT license
+ *   Copyright (C) 2026 OpenCloud GmbH.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+
+package eu.opencloud.android.lib.resources.spaces.responses
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class SpacesResponseTest {
+
+    private lateinit var adapter: JsonAdapter<SpacesResponseWrapper>
+
+    @Before
+    fun setUp() {
+        adapter = Moshi.Builder().build().adapter(SpacesResponseWrapper::class.java)
+    }
+
+    @Test
+    fun `empty quota object is parsed`() {
+        val response = adapter.fromJson(
+            """
+            {
+              "value": [
+                {
+                  "driveType": "personal",
+                  "id": "personal-space-id",
+                  "name": "Personal",
+                  "quota": {},
+                  "root": {
+                    "id": "personal-space-id",
+                    "webDavUrl": "https://server.url/dav/spaces/personal-space-id"
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, response?.value?.size)
+        assertNull(response?.value?.first()?.quota?.total)
+    }
+}

--- a/opencloudData/src/androidTest/java/eu/opencloud/android/data/spaces/db/SpacesDaoTest.kt
+++ b/opencloudData/src/androidTest/java/eu/opencloud/android/data/spaces/db/SpacesDaoTest.kt
@@ -84,6 +84,11 @@ class SpacesDaoTest {
     }
 
     @Test
+    fun insertOrDeleteSpacesWithEmptyListDoesNotCrash() = runTest {
+        spacesDao.insertOrDeleteSpaces(emptyList(), emptyList())
+    }
+
+    @Test
     fun insertOrDeleteSpacesWithSpacesAlreadyInDatabaseNotAttachedToAccountAnymore() = runTest {
         val accountName = OC_SPACE_PROJECT_WITHOUT_IMAGE.accountName
 

--- a/opencloudData/src/main/java/eu/opencloud/android/data/spaces/db/SpacesDao.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/spaces/db/SpacesDao.kt
@@ -41,6 +41,10 @@ interface SpacesDao {
         listOfSpacesEntities: List<SpacesEntity>,
         listOfSpecialEntities: List<SpaceSpecialEntity>,
     ) {
+        if (listOfSpacesEntities.isEmpty()) {
+            return
+        }
+
         val currentAccountName = listOfSpacesEntities.first().accountName
         val currentSpaces = getAllSpacesForAccount(currentAccountName)
 

--- a/opencloudData/src/main/java/eu/opencloud/android/data/spaces/db/SpacesEntity.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/spaces/db/SpacesEntity.kt
@@ -89,7 +89,7 @@ data class SpaceQuotaEntity(
     @ColumnInfo(name = SPACES_QUOTA_STATE)
     val state: String?,
     @ColumnInfo(name = SPACES_QUOTA_TOTAL)
-    val total: Long,
+    val total: Long?,
     @ColumnInfo(name = SPACES_QUOTA_USED)
     val used: Long?,
 )

--- a/opencloudData/src/main/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepository.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepository.kt
@@ -28,8 +28,8 @@ import eu.opencloud.android.data.spaces.datasources.RemoteSpacesDataSource
 import eu.opencloud.android.data.user.datasources.LocalUserDataSource
 import eu.opencloud.android.domain.spaces.SpacesRepository
 import eu.opencloud.android.domain.spaces.model.OCSpace
-import eu.opencloud.android.domain.user.model.UserQuotaState
 import eu.opencloud.android.domain.user.model.UserQuota
+import eu.opencloud.android.domain.user.model.UserQuotaState
 
 class OCSpacesRepository(
     private val localSpacesDataSource: LocalSpacesDataSource,
@@ -43,18 +43,35 @@ class OCSpacesRepository(
             val personalSpace = listOfSpaces.find { it.isPersonal }
             val capabilities = localCapabilitiesDataSource.getCapabilitiesForAccount(accountName)
             val isMultiPersonal = capabilities?.spaces?.hasMultiplePersonalSpaces
-            val userQuota = personalSpace?.let {
-                if (isMultiPersonal == true) {
-                    UserQuota(accountName, -4, 0, 0, UserQuotaState.NORMAL)
-                } else if (it.quota?.total!!.toInt() == 0) {
-                    UserQuota(accountName, -3, it.quota?.used!!, it.quota?.total!!, UserQuotaState.fromValue(it.quota?.state!!))
-                } else {
-                    UserQuota(accountName, it.quota?.remaining!!, it.quota?.used!!, it.quota?.total!!, UserQuotaState.fromValue(it.quota?.state!!))
-                }
-            } ?: UserQuota(accountName, -4, 0, 0, UserQuotaState.NORMAL)
+            val userQuota = getUserQuotaForPersonalSpace(accountName, personalSpace, isMultiPersonal == true)
             localUserDataSource.saveQuotaForAccount(accountName, userQuota)
         }
     }
+
+    private fun getUserQuotaForPersonalSpace(
+        accountName: String,
+        personalSpace: OCSpace?,
+        isMultiPersonal: Boolean,
+    ): UserQuota {
+        if (isMultiPersonal || personalSpace == null) {
+            return unavailableQuota(accountName)
+        }
+
+        val quota = personalSpace.quota ?: return unavailableQuota(accountName)
+        val total = quota.total ?: return unavailableQuota(accountName)
+        val used = quota.used ?: 0
+        val state = quota.state?.let { UserQuotaState.fromValue(it) } ?: UserQuotaState.NORMAL
+
+        return if (total == 0L) {
+            UserQuota(accountName, -3, used, total, state)
+        } else {
+            val remaining = quota.remaining ?: (total - used).coerceAtLeast(0)
+            UserQuota(accountName, remaining, used, total, state)
+        }
+    }
+
+    private fun unavailableQuota(accountName: String) =
+        UserQuota(accountName, -4, 0, 0, UserQuotaState.NORMAL)
 
     override fun getSpacesFromEveryAccountAsStream() =
         localSpacesDataSource.getSpacesFromEveryAccountAsStream()

--- a/opencloudData/src/main/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepository.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepository.kt
@@ -39,6 +39,12 @@ class OCSpacesRepository(
 ) : SpacesRepository {
     override fun refreshSpacesForAccount(accountName: String) {
         remoteSpacesDataSource.refreshSpacesForAccount(accountName).also { listOfSpaces ->
+            if (listOfSpaces.isEmpty()) {
+                localSpacesDataSource.deleteSpacesForAccount(accountName)
+                localUserDataSource.saveQuotaForAccount(accountName, unavailableQuota(accountName))
+                return@also
+            }
+
             localSpacesDataSource.saveSpacesForAccount(listOfSpaces)
             val personalSpace = listOfSpaces.find { it.isPersonal }
             val capabilities = localCapabilitiesDataSource.getCapabilitiesForAccount(accountName)

--- a/opencloudData/src/test/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepositoryTest.kt
+++ b/opencloudData/src/test/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepositoryTest.kt
@@ -176,6 +176,25 @@ class OCSpacesRepositoryTest {
     }
 
     @Test
+    fun `refreshSpacesForAccount clears local spaces when remote returns empty list`() {
+        every {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+        } returns emptyList()
+
+        ocSpacesRepository.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+
+        verify(exactly = 1) {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+            localSpacesDataSource.deleteSpacesForAccount(OC_ACCOUNT_NAME)
+            localUserDataSource.saveQuotaForAccount(OC_ACCOUNT_NAME, OC_USER_QUOTA_WITHOUT_PERSONAL)
+        }
+        verify(exactly = 0) {
+            localSpacesDataSource.saveSpacesForAccount(any())
+            localCapabilitiesDataSource.getCapabilitiesForAccount(any())
+        }
+    }
+
+    @Test
     fun `getSpacesFromEveryAccountAsStream returns a Flow with a list of OCSpace`() = runTest {
         every {
             localSpacesDataSource.getSpacesFromEveryAccountAsStream()

--- a/opencloudData/src/test/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepositoryTest.kt
+++ b/opencloudData/src/test/java/eu/opencloud/android/data/spaces/repository/OCSpacesRepositoryTest.kt
@@ -28,8 +28,10 @@ import eu.opencloud.android.testutil.OC_ACCOUNT_NAME
 import eu.opencloud.android.testutil.OC_CAPABILITY
 import eu.opencloud.android.testutil.OC_CAPABILITY_WITH_MULTIPERSONAL_ENABLED
 import eu.opencloud.android.testutil.OC_SPACE_PERSONAL
+import eu.opencloud.android.testutil.OC_SPACE_PERSONAL_WITH_EMPTY_QUOTA
 import eu.opencloud.android.testutil.OC_SPACE_PERSONAL_WITH_LIMITED_QUOTA
 import eu.opencloud.android.testutil.OC_SPACE_PERSONAL_WITH_UNLIMITED_QUOTA
+import eu.opencloud.android.testutil.OC_SPACE_PERSONAL_WITHOUT_QUOTA
 import eu.opencloud.android.testutil.OC_SPACE_PROJECT_WITH_IMAGE
 import eu.opencloud.android.testutil.OC_USER_QUOTA_LIMITED
 import eu.opencloud.android.testutil.OC_USER_QUOTA_UNLIMITED
@@ -128,6 +130,46 @@ class OCSpacesRepositoryTest {
         verify(exactly = 1) {
             remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
             localSpacesDataSource.saveSpacesForAccount(listOf(OC_SPACE_PROJECT_WITH_IMAGE))
+            localCapabilitiesDataSource.getCapabilitiesForAccount(OC_ACCOUNT_NAME)
+            localUserDataSource.saveQuotaForAccount(OC_ACCOUNT_NAME, OC_USER_QUOTA_WITHOUT_PERSONAL)
+        }
+    }
+
+    @Test
+    fun `refreshSpacesForAccount refreshes spaces for account correctly when quota is missing`() {
+        every {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+        } returns listOf(OC_SPACE_PERSONAL_WITHOUT_QUOTA)
+
+        every {
+            localCapabilitiesDataSource.getCapabilitiesForAccount(OC_ACCOUNT_NAME)
+        } returns OC_CAPABILITY
+
+        ocSpacesRepository.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+
+        verify(exactly = 1) {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+            localSpacesDataSource.saveSpacesForAccount(listOf(OC_SPACE_PERSONAL_WITHOUT_QUOTA))
+            localCapabilitiesDataSource.getCapabilitiesForAccount(OC_ACCOUNT_NAME)
+            localUserDataSource.saveQuotaForAccount(OC_ACCOUNT_NAME, OC_USER_QUOTA_WITHOUT_PERSONAL)
+        }
+    }
+
+    @Test
+    fun `refreshSpacesForAccount refreshes spaces for account correctly when quota is empty`() {
+        every {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+        } returns listOf(OC_SPACE_PERSONAL_WITH_EMPTY_QUOTA)
+
+        every {
+            localCapabilitiesDataSource.getCapabilitiesForAccount(OC_ACCOUNT_NAME)
+        } returns OC_CAPABILITY
+
+        ocSpacesRepository.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+
+        verify(exactly = 1) {
+            remoteSpacesDataSource.refreshSpacesForAccount(OC_ACCOUNT_NAME)
+            localSpacesDataSource.saveSpacesForAccount(listOf(OC_SPACE_PERSONAL_WITH_EMPTY_QUOTA))
             localCapabilitiesDataSource.getCapabilitiesForAccount(OC_ACCOUNT_NAME)
             localUserDataSource.saveQuotaForAccount(OC_ACCOUNT_NAME, OC_USER_QUOTA_WITHOUT_PERSONAL)
         }

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/spaces/model/OCSpace.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/spaces/model/OCSpace.kt
@@ -64,7 +64,7 @@ data class SpaceOwner(
 data class SpaceQuota(
     val remaining: Long?,
     val state: String?,
-    val total: Long,
+    val total: Long?,
     val used: Long?,
 )
 

--- a/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/OCSpace.kt
+++ b/opencloudTestUtil/src/main/java/eu/opencloud/android/testutil/OCSpace.kt
@@ -146,6 +146,19 @@ val OC_SPACE_PERSONAL_WITH_LIMITED_QUOTA = OC_SPACE_PERSONAL.copy(
     )
 )
 
+val OC_SPACE_PERSONAL_WITHOUT_QUOTA = OC_SPACE_PERSONAL.copy(
+    quota = null
+)
+
+val OC_SPACE_PERSONAL_WITH_EMPTY_QUOTA = OC_SPACE_PERSONAL.copy(
+    quota = SpaceQuota(
+        remaining = null,
+        state = null,
+        total = null,
+        used = null
+    )
+)
+
 val OC_SPACE_SHARES = OCSpace(
     accountName = OC_ACCOUNT_NAME,
     driveAlias = "virtual/shares",


### PR DESCRIPTION
## Summary
- handle empty drive list responses without crashing space refresh
- clear stored spaces for the account when the server returns no spaces
- keep the DAO safe against accidental empty inserts

## Tests
- Added coverage for empty space refresh responses
- Added DAO coverage for empty space lists