### PR TITLE
Fix opening PDF files with external viewers

### DIFF
--- a/opencloudApp/src/main/AndroidManifest.xml
+++ b/opencloudApp/src/main/AndroidManifest.xml
@@ -45,6 +45,22 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.REORDER_TASKS" />
 
+    <!-- Android 11+ package visibility: allow discovering apps that handle file open/send -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND_MULTIPLE" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
+
     <application
         android:name=".MainApp"
         android:allowBackup="false"

--- a/opencloudApp/src/main/AndroidManifest.xml
+++ b/opencloudApp/src/main/AndroidManifest.xml
@@ -45,11 +45,12 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.REORDER_TASKS" />
 
-    <!-- Android 11+ package visibility: allow discovering apps that handle file open/send -->
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:mimeType="*/*" />
+            <data
+                android:mimeType="*/*"
+                android:scheme="content" />
         </intent>
         <intent>
             <action android:name="android.intent.action.SEND" />

--- a/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
@@ -162,7 +162,7 @@ private fun getIntentForSavedMimeType(data: Uri, type: String): Intent {
 private fun getIntentForGuessedMimeType(storagePath: String, type: String, data: Uri): Intent? {
     var intentForGuessedMimeType: Intent? = null
     if (storagePath.lastIndexOf('.') >= 0) {
-        val guessedMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(storagePath, type)
+        val guessedMimeType = MimetypeIconUtil.getBestMimeTypeForOpen(type, storagePath)
         if (guessedMimeType != type) {
             intentForGuessedMimeType = Intent(Intent.ACTION_VIEW)
             intentForGuessedMimeType.setDataAndType(data, guessedMimeType)
@@ -455,7 +455,7 @@ fun FragmentActivity.sendDownloadedFilesByShareSheet(ocFiles: List<OCFile>) {
 }
 
 fun Activity.openOCFile(ocFile: OCFile) {
-    val finalMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(ocFile.fileName, ocFile.mimeType)
+    val finalMimeType = MimetypeIconUtil.getBestMimeTypeForOpen(ocFile.mimeType, ocFile.fileName)
 
     val intentForSavedMimeType = Intent(Intent.ACTION_VIEW).apply {
         setDataAndType(getExposedFileUriForOCFile(this@openOCFile, ocFile), finalMimeType)

--- a/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
@@ -33,7 +33,6 @@ import android.net.Uri
 import android.text.method.LinkMovementMethod
 import android.util.TypedValue
 import android.view.inputmethod.InputMethodManager
-import android.webkit.MimeTypeMap
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -163,8 +162,8 @@ private fun getIntentForSavedMimeType(data: Uri, type: String): Intent {
 private fun getIntentForGuessedMimeType(storagePath: String, type: String, data: Uri): Intent? {
     var intentForGuessedMimeType: Intent? = null
     if (storagePath.lastIndexOf('.') >= 0) {
-        val guessedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(storagePath.substring(storagePath.lastIndexOf('.') + 1))
-        if (guessedMimeType != null && guessedMimeType != type) {
+        val guessedMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(storagePath, type)
+        if (guessedMimeType != type) {
             intentForGuessedMimeType = Intent(Intent.ACTION_VIEW)
             intentForGuessedMimeType.setDataAndType(data, guessedMimeType)
             intentForGuessedMimeType.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
@@ -456,8 +455,10 @@ fun FragmentActivity.sendDownloadedFilesByShareSheet(ocFiles: List<OCFile>) {
 }
 
 fun Activity.openOCFile(ocFile: OCFile) {
+    val finalMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(ocFile.fileName, ocFile.mimeType)
+
     val intentForSavedMimeType = Intent(Intent.ACTION_VIEW).apply {
-        setDataAndType(getExposedFileUriForOCFile(this@openOCFile, ocFile), ocFile.mimeType)
+        setDataAndType(getExposedFileUriForOCFile(this@openOCFile, ocFile), finalMimeType)
         flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
         if (ocFile.hasWritePermission) {
             flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION

--- a/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/extensions/ActivityExt.kt
@@ -33,6 +33,7 @@ import android.net.Uri
 import android.text.method.LinkMovementMethod
 import android.util.TypedValue
 import android.view.inputmethod.InputMethodManager
+import android.webkit.MimeTypeMap
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -162,8 +163,8 @@ private fun getIntentForSavedMimeType(data: Uri, type: String): Intent {
 private fun getIntentForGuessedMimeType(storagePath: String, type: String, data: Uri): Intent? {
     var intentForGuessedMimeType: Intent? = null
     if (storagePath.lastIndexOf('.') >= 0) {
-        val guessedMimeType = MimetypeIconUtil.getBestMimeTypeForOpen(type, storagePath)
-        if (guessedMimeType != type) {
+        val guessedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(storagePath.substring(storagePath.lastIndexOf('.') + 1))
+        if (guessedMimeType != null && guessedMimeType != type) {
             intentForGuessedMimeType = Intent(Intent.ACTION_VIEW)
             intentForGuessedMimeType.setDataAndType(data, guessedMimeType)
             intentForGuessedMimeType.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION

--- a/opencloudApp/src/main/java/eu/opencloud/android/ui/helpers/FileOperationsHelper.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/ui/helpers/FileOperationsHelper.java
@@ -31,7 +31,6 @@ import android.accounts.AccountManager;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
-import android.webkit.MimeTypeMap;
 
 import eu.opencloud.android.R;
 import eu.opencloud.android.domain.files.model.OCFile;
@@ -43,6 +42,7 @@ import eu.opencloud.android.services.OperationsService;
 import eu.opencloud.android.ui.activity.FileActivity;
 import eu.opencloud.android.usecases.synchronization.SynchronizeFileUseCase;
 import eu.opencloud.android.usecases.synchronization.SynchronizeFolderUseCase;
+import eu.opencloud.android.utils.MimetypeIconUtil;
 import eu.opencloud.android.utils.UriUtilsKt;
 import kotlin.Lazy;
 import org.jetbrains.annotations.NotNull;
@@ -78,9 +78,9 @@ public class FileOperationsHelper {
         Intent intentForGuessedMimeType = null;
 
         if (storagePath != null && storagePath.lastIndexOf('.') >= 0) {
-            String guessedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(storagePath.substring(storagePath.lastIndexOf('.') + 1));
+            String guessedMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(storagePath, type);
 
-            if (guessedMimeType != null && !guessedMimeType.equals(type)) {
+            if (!guessedMimeType.equals(type)) {
                 intentForGuessedMimeType = new Intent(Intent.ACTION_VIEW);
                 intentForGuessedMimeType.setDataAndType(data, guessedMimeType);
                 int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION;

--- a/opencloudApp/src/main/java/eu/opencloud/android/ui/helpers/FileOperationsHelper.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/ui/helpers/FileOperationsHelper.java
@@ -74,48 +74,20 @@ public class FileOperationsHelper {
         return intentForSavedMimeType;
     }
 
-    private Intent getIntentForGuessedMimeType(String storagePath, String type, Uri data, boolean hasWritePermission) {
-        Intent intentForGuessedMimeType = null;
-
-        if (storagePath != null && storagePath.lastIndexOf('.') >= 0) {
-            String guessedMimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(storagePath, type);
-
-            if (!guessedMimeType.equals(type)) {
-                intentForGuessedMimeType = new Intent(Intent.ACTION_VIEW);
-                intentForGuessedMimeType.setDataAndType(data, guessedMimeType);
-                int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
-                if (hasWritePermission) {
-                    flags = flags | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
-                }
-                intentForGuessedMimeType.setFlags(flags);
-            }
-        }
-        return intentForGuessedMimeType;
-    }
-
     public void openFile(OCFile ocFile) {
         if (ocFile != null) {
+            String finalMimeType = MimetypeIconUtil.getBestMimeTypeForOpen(ocFile.getMimeType(), ocFile.getFileName());
             Intent intentForSavedMimeType = getIntentForSavedMimeType(UriUtilsKt.INSTANCE.getExposedFileUriForOCFile(mFileActivity, ocFile),
-                    ocFile.getMimeType(), ocFile.getHasWritePermission());
+                    finalMimeType, ocFile.getHasWritePermission());
 
-            Intent intentForGuessedMimeType = getIntentForGuessedMimeType(ocFile.getStoragePath(), ocFile.getMimeType(),
-                    UriUtilsKt.INSTANCE.getExposedFileUriForOCFile(mFileActivity, ocFile), ocFile.getHasWritePermission());
-
-            openFileWithIntent(intentForSavedMimeType, intentForGuessedMimeType);
+            openFileWithIntent(intentForSavedMimeType);
 
         } else {
             Timber.e("Trying to open a NULL OCFile");
         }
     }
 
-    private void openFileWithIntent(Intent intentForSavedMimeType, Intent intentForGuessedMimeType) {
-        Intent openFileWithIntent;
-
-        if (intentForGuessedMimeType != null) {
-            openFileWithIntent = intentForGuessedMimeType;
-        } else {
-            openFileWithIntent = intentForSavedMimeType;
-        }
+    private void openFileWithIntent(Intent openFileWithIntent) {
         try {
             mFileActivity.startActivity(Intent.createChooser(openFileWithIntent, mFileActivity.getString(R.string.actionbar_open_with)));
         } catch (ActivityNotFoundException anfe) {

--- a/opencloudApp/src/main/java/eu/opencloud/android/utils/MimetypeIconUtil.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/utils/MimetypeIconUtil.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -102,18 +103,26 @@ public class MimetypeIconUtil {
     }
 
     /**
-     * Returns a MIME type from the file extension, or {@code defaultMimeType} when the extension is unknown.
+     * Returns the server MIME type unless it is generic, then falls back to the file extension.
      *
-     * @param filename        Name of file
-     * @param defaultMimeType Fallback MIME type
-     * @return Best known MIME type for the file
+     * @param serverMimeType MIME type reported by the server
+     * @param filename       Name of file
+     * @return MIME type to use when opening the file
      */
-    public static String getBestMimeTypeByFilenameOrDefault(String filename, String defaultMimeType) {
-        String mimeType = getBestMimeTypeByFilename(filename);
-        if (mimeType == null || mimeType.isEmpty() || UNKNOWN_MIME_TYPE.equals(mimeType)) {
-            return defaultMimeType;
+    public static String getBestMimeTypeForOpen(String serverMimeType, String filename) {
+        if (!isGenericMimeType(serverMimeType)) {
+            return serverMimeType;
         }
-        return mimeType;
+
+        String mimeTypeFromFilename = getBestMimeTypeByFilename(filename);
+        if (isGenericMimeType(mimeTypeFromFilename)) {
+            return UNKNOWN_MIME_TYPE;
+        }
+        return mimeTypeFromFilename;
+    }
+
+    private static boolean isGenericMimeType(String mimeType) {
+        return mimeType == null || mimeType.trim().isEmpty() || UNKNOWN_MIME_TYPE.equals(mimeType) || "*/*".equals(mimeType);
     }
 
     /**
@@ -184,8 +193,16 @@ public class MimetypeIconUtil {
      * @return the file extension
      */
     private static String getExtension(String filename) {
-        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
-        return extension;
+        if (filename == null || filename.isEmpty()) {
+            return "";
+        }
+
+        int extensionStart = filename.lastIndexOf(".");
+        if (extensionStart < 0 || extensionStart == filename.length() - 1) {
+            return "";
+        }
+
+        return filename.substring(extensionStart + 1).toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/opencloudApp/src/main/java/eu/opencloud/android/utils/MimetypeIconUtil.java
+++ b/opencloudApp/src/main/java/eu/opencloud/android/utils/MimetypeIconUtil.java
@@ -60,6 +60,7 @@ public class MimetypeIconUtil {
     /** Mapping: mime type for file extension. */
     private static final Map<String, List<String>> FILE_EXTENSION_TO_MIMETYPE_MAPPING =
             new HashMap<String, List<String>>();
+    public static final String UNKNOWN_MIME_TYPE = "application/octet-stream";
 
     static {
         populateFileExtensionMimeTypeMapping();
@@ -95,9 +96,24 @@ public class MimetypeIconUtil {
     public static String getBestMimeTypeByFilename(String filename) {
         List<String> candidates = determineMimeTypesByFilename(filename);
         if (candidates == null || candidates.size() < 1) {
-            return "application/octet-stream";
+            return UNKNOWN_MIME_TYPE;
         }
         return candidates.get(0);
+    }
+
+    /**
+     * Returns a MIME type from the file extension, or {@code defaultMimeType} when the extension is unknown.
+     *
+     * @param filename        Name of file
+     * @param defaultMimeType Fallback MIME type
+     * @return Best known MIME type for the file
+     */
+    public static String getBestMimeTypeByFilenameOrDefault(String filename, String defaultMimeType) {
+        String mimeType = getBestMimeTypeByFilename(filename);
+        if (mimeType == null || mimeType.isEmpty() || UNKNOWN_MIME_TYPE.equals(mimeType)) {
+            return defaultMimeType;
+        }
+        return mimeType;
     }
 
     /**
@@ -151,7 +167,8 @@ public class MimetypeIconUtil {
             return mimeTypeList;
         } else {
             // try detecting the mime type via android itself
-            String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
+            MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
+            String mimeType = mimeTypeMap != null ? mimeTypeMap.getMimeTypeFromExtension(fileExtension) : null;
             if (mimeType != null) {
                 return Collections.singletonList(mimeType);
             } else {
@@ -186,7 +203,7 @@ public class MimetypeIconUtil {
         MIMETYPE_TO_ICON_MAPPING.put("application/msexcel", R.drawable.file_xls);
         MIMETYPE_TO_ICON_MAPPING.put("application/mspowerpoint", R.drawable.file_ppt);
         MIMETYPE_TO_ICON_MAPPING.put("application/msword", R.drawable.file_doc);
-        MIMETYPE_TO_ICON_MAPPING.put("application/octet-stream", R.drawable.file);
+        MIMETYPE_TO_ICON_MAPPING.put(UNKNOWN_MIME_TYPE, R.drawable.file);
         MIMETYPE_TO_ICON_MAPPING.put("application/postscript", R.drawable.file_image);
         MIMETYPE_TO_ICON_MAPPING.put("application/pdf", R.drawable.file_pdf);
         MIMETYPE_TO_ICON_MAPPING.put("application/rss+xml", R.drawable.file_code);

--- a/opencloudApp/src/test/java/eu/opencloud/android/utils/MimetypeIconUtilTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/utils/MimetypeIconUtilTest.kt
@@ -1,0 +1,47 @@
+/**
+ * openCloud Android client application
+ *
+ * Copyright (C) 2026 openCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.opencloud.android.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MimetypeIconUtilTest {
+
+    @Test
+    fun `getBestMimeTypeByFilenameOrDefault prefers known file extension`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(
+            "Invoice.PDF",
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+        )
+
+        assertEquals("application/pdf", mimeType)
+    }
+
+    @Test
+    fun `getBestMimeTypeByFilenameOrDefault falls back for unknown file extension`() {
+        val fallbackMimeType = "application/x-opencloud-test"
+
+        val mimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(
+            "file.unknownextension",
+            fallbackMimeType,
+        )
+
+        assertEquals(fallbackMimeType, mimeType)
+    }
+}

--- a/opencloudApp/src/test/java/eu/opencloud/android/utils/MimetypeIconUtilTest.kt
+++ b/opencloudApp/src/test/java/eu/opencloud/android/utils/MimetypeIconUtilTest.kt
@@ -24,24 +24,102 @@ import org.junit.Test
 class MimetypeIconUtilTest {
 
     @Test
-    fun `getBestMimeTypeByFilenameOrDefault prefers known file extension`() {
-        val mimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(
+    fun `getBestMimeTypeForOpen keeps specific server mime type`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeForOpen(
+            "application/pdf",
             "Invoice.PDF",
-            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
         )
 
         assertEquals("application/pdf", mimeType)
     }
 
     @Test
-    fun `getBestMimeTypeByFilenameOrDefault falls back for unknown file extension`() {
-        val fallbackMimeType = "application/x-opencloud-test"
-
-        val mimeType = MimetypeIconUtil.getBestMimeTypeByFilenameOrDefault(
-            "file.unknownextension",
-            fallbackMimeType,
+    fun `getBestMimeTypeForOpen uses file extension when server mime type is generic`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeForOpen(
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+            "Invoice.PDF",
         )
 
-        assertEquals(fallbackMimeType, mimeType)
+        assertEquals("application/pdf", mimeType)
+    }
+
+    @Test
+    fun `getBestMimeTypeForOpen uses file extension when server mime type is wildcard`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeForOpen(
+            "*/*",
+            "Invoice.PDF",
+        )
+
+        assertEquals("application/pdf", mimeType)
+    }
+
+    @Test
+    fun `getBestMimeTypeForOpen uses file extension when server mime type is null or blank`() {
+        assertEquals(
+            "application/pdf",
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                null,
+                "Invoice.PDF",
+            )
+        )
+        assertEquals(
+            "application/pdf",
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                "",
+                "Invoice.PDF",
+            )
+        )
+        assertEquals(
+            "application/pdf",
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                " ",
+                "Invoice.PDF",
+            )
+        )
+    }
+
+    @Test
+    fun `getBestMimeTypeForOpen does not override specific server mime type`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeForOpen(
+            "text/markdown",
+            "Invoice.PDF",
+        )
+
+        assertEquals("text/markdown", mimeType)
+    }
+
+    @Test
+    fun `getBestMimeTypeForOpen falls back to unknown mime type for unknown extension`() {
+        val mimeType = MimetypeIconUtil.getBestMimeTypeForOpen(
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+            "Invoice.notarealextension",
+        )
+
+        assertEquals(MimetypeIconUtil.UNKNOWN_MIME_TYPE, mimeType)
+    }
+
+    @Test
+    fun `getBestMimeTypeForOpen handles filenames without extensions`() {
+        assertEquals(
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+                "Invoice",
+            )
+        )
+        assertEquals(
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+                "",
+            )
+        )
+        assertEquals(
+            MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+            MimetypeIconUtil.getBestMimeTypeForOpen(
+                MimetypeIconUtil.UNKNOWN_MIME_TYPE,
+                null,
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes #139.

This changes the file-open intent MIME type selection so known file extensions are used when the stored MIME type is generic or missing. Concrete MIME types reported by the server are kept as-is; this keeps WebDAV metadata as the source of truth while still opening downloaded `*.pdf` files with `application/pdf` when the stored type is `application/octet-stream`, `*/*`, blank, or missing.

The same MIME fallback is used in both `OCFile` file-open flows, and the manifest declares Android 11+ package visibility queries needed by explicit handler lookups for view/send intents.

## Changes

- Add `MimetypeIconUtil.getBestMimeTypeForOpen(...)`
- Use the same generic-MIME fallback when opening `OCFile`s from both file-open flows
- Add Android 11+ `<queries>` entries for `VIEW`, `SEND`, and `SEND_MULTIPLE`
- Add unit coverage for generic, wildcard, null/blank, unknown-extension, no-extension, and concrete-MIME behavior

## Validation

- `./gradlew.bat :opencloudApp:testOriginalDebugUnitTest --tests eu.opencloud.android.utils.MimetypeIconUtilTest`
- `./gradlew.bat detekt`
- `./gradlew.bat assembleDebug`
- Verified the merged manifest contains the `VIEW`, `SEND`, and `SEND_MULTIPLE` package visibility queries
