### PR TITLE
Harden parsing for optional backend response fields

### DIFF
--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/responses/ShareItem.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/responses/ShareItem.kt
@@ -73,7 +73,7 @@ data class ShareItem(
     fun toRemoteShare() = RemoteShare(
         id = id ?: "0",
         shareWith = shareWith.orEmpty(),
-        path = if (itemType == ItemType.FOLDER.fileValue) path.plus(File.separator) else path.orEmpty(),
+        path = if (itemType == ItemType.FOLDER.fileValue) path?.plus(File.separator).orEmpty() else path.orEmpty(),
         token = token.orEmpty(),
         itemType = itemType.orEmpty(),
         sharedWithDisplayName = sharedWithDisplayName.orEmpty(),

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/appregistry/responses/AppRegistryResponseTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/appregistry/responses/AppRegistryResponseTest.kt
@@ -1,7 +1,5 @@
 /* openCloud Android Library is available under MIT license
- *   @author Abel García de Prada
- *
- *   Copyright (C) 2023 ownCloud GmbH.
+ *   Copyright (C) 2026 openCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -25,34 +23,41 @@
  */
 package eu.opencloud.android.lib.resources.appregistry.responses
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryResponse(
-    @Json(name = "mime-types")
-    val value: List<AppRegistryMimeTypeResponse>
-)
+class AppRegistryResponseTest {
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryMimeTypeResponse(
-    @Json(name = "mime_type") val mimeType: String,
-    val ext: String? = null,
-    @Json(name = "app_providers")
-    val appProviders: List<AppRegistryProviderResponse>,
-    val name: String? = null,
-    val icon: String? = null,
-    val description: String? = null,
-    @Json(name = "allow_creation")
-    val allowCreation: Boolean? = null,
-    @Json(name = "default_application")
-    val defaultApplication: String? = null
-)
+    private val adapter = Moshi.Builder().build().adapter(AppRegistryResponse::class.java)
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryProviderResponse(
-    val name: String,
-    @Json(name = "product_name")
-    val productName: String? = null,
-    val icon: String,
-)
+    @Test
+    fun parsesBackendProvidersWithoutProductName() {
+        val response = adapter.fromJson(
+            """
+            {
+              "mime-types": [
+                {
+                  "mime_type": "application/pdf",
+                  "ext": "pdf",
+                  "app_providers": [
+                    {
+                      "name": "OnlyOffice",
+                      "icon": "https://some-website.test/onlyoffice-pdf-icon.png"
+                    }
+                  ],
+                  "name": "PDF",
+                  "description": "PDF document"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val provider = response!!.value.single().appProviders.single()
+        assertEquals("OnlyOffice", provider.name)
+        assertNull(provider.productName)
+        assertEquals("https://some-website.test/onlyoffice-pdf-icon.png", provider.icon)
+    }
+}

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/shares/responses/ShareItemTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/shares/responses/ShareItemTest.kt
@@ -1,7 +1,5 @@
 /* openCloud Android Library is available under MIT license
- *   @author Abel García de Prada
- *
- *   Copyright (C) 2023 ownCloud GmbH.
+ *   Copyright (C) 2026 openCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -23,36 +21,28 @@
  *   THE SOFTWARE.
  *
  */
-package eu.opencloud.android.lib.resources.appregistry.responses
+package eu.opencloud.android.lib.resources.shares.responses
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryResponse(
-    @Json(name = "mime-types")
-    val value: List<AppRegistryMimeTypeResponse>
-)
+class ShareItemTest {
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryMimeTypeResponse(
-    @Json(name = "mime_type") val mimeType: String,
-    val ext: String? = null,
-    @Json(name = "app_providers")
-    val appProviders: List<AppRegistryProviderResponse>,
-    val name: String? = null,
-    val icon: String? = null,
-    val description: String? = null,
-    @Json(name = "allow_creation")
-    val allowCreation: Boolean? = null,
-    @Json(name = "default_application")
-    val defaultApplication: String? = null
-)
+    @Test
+    fun folderWithMissingPathDoesNotCreateNullPath() {
+        val remoteShare = ShareItem(itemType = ItemType.FOLDER.fileValue).toRemoteShare()
 
-@JsonClass(generateAdapter = true)
-data class AppRegistryProviderResponse(
-    val name: String,
-    @Json(name = "product_name")
-    val productName: String? = null,
-    val icon: String,
-)
+        assertEquals("", remoteShare.path)
+    }
+
+    @Test
+    fun folderWithPathKeepsTrailingSeparator() {
+        val remoteShare = ShareItem(
+            itemType = ItemType.FOLDER.fileValue,
+            path = "/Documents"
+        ).toRemoteShare()
+
+        assertEquals("/Documents${File.separator}", remoteShare.path)
+    }
+}

--- a/opencloudData/src/main/java/eu/opencloud/android/data/appregistry/datasources/implementation/OCRemoteAppRegistryDataSource.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/appregistry/datasources/implementation/OCRemoteAppRegistryDataSource.kt
@@ -75,7 +75,8 @@ class OCRemoteAppRegistryDataSource(
                     appProviders = appRegistryMimeTypeResponse.appProviders.map { appRegistryProviderResponse ->
                         AppRegistryProvider(
                             name = appRegistryProviderResponse.name,
-                            productName = appRegistryProviderResponse.productName,
+                            productName = appRegistryProviderResponse.productName
+                                ?: appRegistryProviderResponse.name,
                             icon = appRegistryProviderResponse.icon
                         )
                     },

--- a/opencloudData/src/test/java/eu/opencloud/android/data/appregistry/datasources/implementation/OCRemoteAppRegistryDataSourceTest.kt
+++ b/opencloudData/src/test/java/eu/opencloud/android/data/appregistry/datasources/implementation/OCRemoteAppRegistryDataSourceTest.kt
@@ -22,6 +22,10 @@
 package eu.opencloud.android.data.appregistry.datasources.implementation
 
 import eu.opencloud.android.data.ClientManager
+import eu.opencloud.android.domain.appregistry.model.AppRegistryProvider
+import eu.opencloud.android.lib.resources.appregistry.responses.AppRegistryMimeTypeResponse
+import eu.opencloud.android.lib.resources.appregistry.responses.AppRegistryProviderResponse
+import eu.opencloud.android.lib.resources.appregistry.responses.AppRegistryResponse
 import eu.opencloud.android.lib.resources.appregistry.services.OCAppRegistryService
 import eu.opencloud.android.testutil.OC_ACCOUNT_NAME
 import eu.opencloud.android.testutil.OC_APP_REGISTRY
@@ -65,6 +69,43 @@ class OCRemoteAppRegistryDataSourceTest {
         assertEquals(OC_APP_REGISTRY, result)
 
         verify(exactly = 1) { ocAppRegistryService.getAppRegistry(appUrl) }
+    }
+
+    @Test
+    fun `getAppRegistryForAccount defaults missing provider product name to provider name`() {
+        val response = AppRegistryResponse(
+            value = listOf(
+                AppRegistryMimeTypeResponse(
+                    mimeType = "application/pdf",
+                    ext = "pdf",
+                    appProviders = listOf(
+                        AppRegistryProviderResponse(
+                            name = "OnlyOffice",
+                            productName = null,
+                            icon = "https://some-website.test/onlyoffice-pdf-icon.png",
+                        )
+                    ),
+                    name = "PDF",
+                    description = "PDF document",
+                )
+            )
+        )
+        val getAppRegistryForAccountResult = createRemoteOperationResultMock(
+            data = response, isSuccess = true
+        )
+
+        every { ocAppRegistryService.getAppRegistry(appUrl) } returns getAppRegistryForAccountResult
+
+        val result = ocRemoteAppRegistryDataSource.getAppRegistryForAccount(OC_ACCOUNT_NAME, appUrl)
+
+        assertEquals(
+            AppRegistryProvider(
+                name = "OnlyOffice",
+                productName = "OnlyOffice",
+                icon = "https://some-website.test/onlyoffice-pdf-icon.png",
+            ),
+            result.mimetypes.single().appProviders.single()
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- accept app registry providers without product_name
- default missing provider product names to the provider name
- avoid generating null folder paths for malformed or partial share responses

## Tests
- Added app registry parsing coverage for providers without product_name
- Added share parsing coverage for folders with missing path values