### PR TITLE
fix(privacy-policy): route non http(s) links out of the WebView

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
@@ -20,10 +20,13 @@
 
 package eu.opencloud.android.presentation.settings.privacypolicy
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.LinearLayout
@@ -94,6 +97,21 @@ class PrivacyPolicyActivity : AppCompatActivity() {
             webViewClient = object : WebViewClient() {
                 override fun onReceivedError(view: WebView, errorCode: Int, description: String, failingUrl: String) {
                     showMessageInSnackbar(message = getString(R.string.privacy_policy_error) + description)
+                }
+
+                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                    val url = request?.url ?: return false
+                    val scheme = url.scheme?.lowercase()
+                    if (scheme == "http" || scheme == "https") return false
+                    return try {
+                        val intent = Intent(Intent.ACTION_VIEW, url).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        }
+                        startActivity(intent)
+                        true
+                    } catch (e: ActivityNotFoundException) {
+                        false
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes #164.

`PrivacyPolicyActivity.onCreate` sets up the `WebViewClient` with only an `onReceivedError` override, so any link in the privacy policy with a non http(s) scheme (`mailto:`, `tel:`, `intent:`, `market:`, `geo:`, ...) is dispatched by the default WebView handler instead of leaving the WebView for the system app that registered for that scheme. The visible effect is that tapping a `mailto:` link in the policy text shows nothing.

### Change

Override `shouldOverrideUrlLoading`. Keep http(s) inside the WebView, route other schemes to `Intent.ACTION_VIEW`, and wrap the launch in `try/catch (ActivityNotFoundException)` so a device with no handler does not crash the Activity:

```kotlin
override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
    val url = request?.url ?: return false
    val scheme = url.scheme?.lowercase()
    if (scheme == "http" || scheme == "https") return false
    return try {
        val intent = Intent(Intent.ACTION_VIEW, url).apply {
            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
        }
        startActivity(intent)
        true
    } catch (e: ActivityNotFoundException) {
        false
    }
}
```

### Behaviour

- A normal `https://opencloud.eu/privacy` link inside the policy keeps loading in the WebView like before.
- A `mailto:legal@opencloud.eu` link now opens the user's mail app.
- A scheme nothing on the device handles falls through to `false` so the user does not see a crash.
