### PR TITLE
fix: use ISO-8601 format for share expiration dates

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
@@ -41,6 +41,7 @@ import eu.opencloud.android.extensions.showMessageInSnackbar
 import eu.opencloud.android.ui.activity.enableEdgeToEdgePostSetContentView
 import eu.opencloud.android.ui.activity.enableEdgeToEdgePreSetContentView
 import eu.opencloud.android.utils.PreferenceUtils
+import timber.log.Timber
 
 /**
  * Activity to show the privacy policy to the user
@@ -110,6 +111,7 @@ class PrivacyPolicyActivity : AppCompatActivity() {
                         startActivity(intent)
                         true
                     } catch (e: ActivityNotFoundException) {
+                        Timber.w(e, "No activity found to open URL: %s", url)
                         false
                     }
                 }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/CreateRemoteShareOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/CreateRemoteShareOperation.kt
@@ -199,6 +199,9 @@ class CreateRemoteShareOperation(
         private const val PARAM_PERMISSIONS = "permissions"
 
         //Arguments - constant values
+        // ISO-8601 UTC format is required by the backend to correctly parse expiration dates,
+        // especially for private user/group share creations and updates, ensuring compatibility
+        // when these features are eventually exposed in the mobile UI.
         private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     }
 }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/CreateRemoteShareOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/CreateRemoteShareOperation.kt
@@ -137,7 +137,9 @@ class CreateRemoteShareOperation(
         }
 
         if (expirationDateInMillis > INIT_EXPIRATION_DATE_IN_MILLIS) {
-            val dateFormat = SimpleDateFormat(FORMAT_EXPIRATION_DATE, Locale.getDefault())
+            val dateFormat = SimpleDateFormat(FORMAT_EXPIRATION_DATE, Locale.getDefault()).apply {
+                timeZone = java.util.TimeZone.getTimeZone("UTC")
+            }
             val expirationDate = Calendar.getInstance()
             expirationDate.timeInMillis = expirationDateInMillis
             val formattedExpirationDate = dateFormat.format(expirationDate.time)
@@ -197,6 +199,6 @@ class CreateRemoteShareOperation(
         private const val PARAM_PERMISSIONS = "permissions"
 
         //Arguments - constant values
-        private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd"
+        private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     }
 }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/UpdateRemoteShareOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/UpdateRemoteShareOperation.kt
@@ -218,6 +218,9 @@ class UpdateRemoteShareOperation
         private const val PARAM_PERMISSIONS = "permissions"
 
         //Arguments - constant values
+        // ISO-8601 UTC format is required by the backend to correctly parse expiration dates,
+        // especially for private user/group share creations and updates, ensuring compatibility
+        // when these features are eventually exposed in the mobile UI.
         private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         private const val INITIAL_EXPIRATION_DATE_IN_MILLIS: Long = 0
     }

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/UpdateRemoteShareOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/shares/UpdateRemoteShareOperation.kt
@@ -159,7 +159,9 @@ class UpdateRemoteShareOperation
 
         } else if (expirationDateInMillis > INITIAL_EXPIRATION_DATE_IN_MILLIS) {
             // set expiration date
-            val dateFormat = SimpleDateFormat(FORMAT_EXPIRATION_DATE, Locale.getDefault())
+            val dateFormat = SimpleDateFormat(FORMAT_EXPIRATION_DATE, Locale.getDefault()).apply {
+                timeZone = java.util.TimeZone.getTimeZone("UTC")
+            }
             val expirationDate = Calendar.getInstance()
             expirationDate.timeInMillis = expirationDateInMillis
             val formattedExpirationDate = dateFormat.format(expirationDate.time)
@@ -216,7 +218,7 @@ class UpdateRemoteShareOperation
         private const val PARAM_PERMISSIONS = "permissions"
 
         //Arguments - constant values
-        private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd"
+        private const val FORMAT_EXPIRATION_DATE = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         private const val INITIAL_EXPIRATION_DATE_IN_MILLIS: Long = 0
     }
 }


### PR DESCRIPTION
### Description
This change updates the formatting of the share expiration date (`expireDate`) sent by the Android app when creating or updating shares. Currently, the app formats the date as `"yyyy-MM-dd"`.

While the public link sharing endpoint in the backend has a fallback that parses this date-only format, the endpoints for private shares (user/group shares) and space membership do not. 
Specifically:
* `createUserShare` (in `user.go`) expects `_iso8601 = "2006-01-02T15:04:05Z0700"`.
* `updateShare` (in `shares.go`) expects `time.RFC3339` (`"2006-01-02T15:04:05Z07:00"`).
* `addSpaceMember` (in `spaces.go`) expects either layout.

Because `"yyyy-MM-dd"` doesn't match either pattern, creating or updating a private share or space membership with an expiration date always fails with an `HTTP 400 Bad Request` ("could not parse expireDate").

To resolve this without needing backend changes, this PR updates both `CreateRemoteShareOperation` and `UpdateRemoteShareOperation` to format the expiration timestamp as a standard UTC ISO-8601 string (`"yyyy-MM-dd'T'HH:mm:ss'Z'"`), which parses successfully across all backend endpoints.

> [!NOTE]
> Currently, the app does not support setting expiration dates for private shares anyway, but this fix ensures that the API structure is already perfectly prepared and compatible for future implementations.

### Changes
* Changed `FORMAT_EXPIRATION_DATE` pattern to `"yyyy-MM-dd'T'HH:mm:ss'Z'"` in `CreateRemoteShareOperation.kt` and `UpdateRemoteShareOperation.kt`.
* Configured `SimpleDateFormat` to use the `UTC` timezone.
