### PR TITLE
Propagate TUS upload body errors and close file handles

### DIFF
--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/ChunkFromFileRequestBody.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/common/network/ChunkFromFileRequestBody.kt
@@ -88,6 +88,7 @@ class ChunkFromFileRequestBody(
             }
         } catch (exception: Exception) {
             Timber.e(exception, "Transferred " + alreadyTransferred + " bytes from a total of " + file.length())
+            throw exception
         }
     }
 

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/files/tus/CreateTusUploadRemoteOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/files/tus/CreateTusUploadRemoteOperation.kt
@@ -46,123 +46,166 @@ class CreateTusUploadRemoteOperation(
             Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
-    override fun run(client: OpenCloudClient): RemoteOperationResult<CreationResult> = try {
-        // Determine TUS endpoint URL based on provided parameters
-        val targetFileUrl = if (!tusUrl.isNullOrBlank()) {
-            tusUrl
-        } else {
-            val baseCollection = (collectionUrlOverride
-                ?: client.userFilesWebDavUri.toString()).trim()
-            // Remove trailing slash - OpenCloud expects no slash on space endpoints
-            val resolvedCollection = buildCollectionUrl(baseCollection, remotePath).trimEnd('/')
-            Timber.d("TUS resolved collection: %s", resolvedCollection)
-            resolvedCollection
-        }
+    private data class CreationRequestBody(
+        val body: RequestBody,
+        val fileToClose: RandomAccessFile?
+    )
 
+    override fun run(client: OpenCloudClient): RemoteOperationResult<CreationResult> {
+        var creationUploadFile: RandomAccessFile? = null
+        return try {
+            val targetFileUrl = resolveTargetFileUrl(client)
             Timber.d("TUS Creation URL: %s", targetFileUrl)
 
-            // Prepare request body first
-            val postBody: RequestBody = if (useCreationWithUpload && (firstChunkSize ?: 0L) > 0L) {
-                // creation-with-upload: include first chunk
-                // Don't use .use{} here - the channel must stay open for OkHttp to read
-                val raf = RandomAccessFile(file, "r")
-                val channel: FileChannel = raf.channel
-                ChunkFromFileRequestBody(
-                    file = file,
-                    contentType = HttpConstants.CONTENT_TYPE_OFFSET_OCTET_STREAM.toMediaTypeOrNull(),
-                    channel = channel,
-                    chunkSize = firstChunkSize!!
-                )
-            } else {
-                // creation only: empty body
-                ByteArray(0).toRequestBody(null)
-            }
-
-            val postMethod = PostMethod(URL(targetFileUrl), postBody)
-
-            // Set TUS headers
-            postMethod.setRequestHeader(HttpConstants.TUS_RESUMABLE, "1.0.0")
-            postMethod.setRequestHeader(HttpConstants.UPLOAD_LENGTH, file.length().toString())
-            postMethod.setRequestHeader(HttpConstants.CONTENT_TYPE_HEADER, HttpConstants.CONTENT_TYPE_OFFSET_OCTET_STREAM)
-            // Set TUS-Extension header to indicate which extensions we want to use
-            val extensions = if (useCreationWithUpload && (firstChunkSize ?: 0L) > 0L) {
-                "creation,creation-with-upload"
-            } else {
-                "creation"
-            }
-            postMethod.setRequestHeader(HttpConstants.TUS_EXTENSION, extensions)
-
-            // Prepare Upload-Metadata like iOS SDK
-            val allMetadata = metadata.toMutableMap()
-            allMetadata.putIfAbsent("filename", remotePath.substringAfterLast('/'))
-            allMetadata.putIfAbsent("mtime", (file.lastModified() / 1000).toString())
-
-            if (allMetadata.isNotEmpty()) {
-                postMethod.setRequestHeader(HttpConstants.UPLOAD_METADATA, encodeTusMetadata(allMetadata))
-            }
-
-            // Set Upload-Offset for creation-with-upload
-            if (useCreationWithUpload && (firstChunkSize ?: 0L) > 0L) {
-                postMethod.setRequestHeader(HttpConstants.UPLOAD_OFFSET, "0")
-            }
+            val creationRequestBody = buildCreationRequestBody()
+            creationUploadFile = creationRequestBody.fileToClose
+            val postMethod = PostMethod(URL(targetFileUrl), creationRequestBody.body)
+            configureCreationRequest(postMethod)
 
             val status = client.executeHttpMethod(postMethod)
             Timber.d("TUS Creation [%s] - %d%s", targetFileUrl, status, if (!isSuccess(status)) " (FAIL)" else "")
             if (!isSuccess(status)) {
-                Timber.w("TUS Creation failed - Status: %d", status)
-                Timber.w("  Target URL: %s", targetFileUrl)
-                Timber.w("  Collection Override: %s", collectionUrlOverride)
-                Timber.w("  User Files WebDAV: %s", client.userFilesWebDavUri)
-                Timber.w("  Remote Path: %s", remotePath)
-                Timber.w("  File Size: %d bytes", file.length())
-                Timber.w("  Tus-Resumable: %s", postMethod.getRequestHeader(HttpConstants.TUS_RESUMABLE))
-                Timber.w("  Upload-Length: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_LENGTH))
-                Timber.w("  Upload-Metadata: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_METADATA))
+                logCreationFailure(status, targetFileUrl, postMethod, client)
             }
 
-            // Debug logging for troubleshooting
-            if (status == 412) {
-                Timber.w("HTTP 412 Precondition Failed - Request headers:")
-                Timber.w("  Tus-Resumable: %s", postMethod.getRequestHeader(HttpConstants.TUS_RESUMABLE))
-                Timber.w("  Tus-Extension: %s", postMethod.getRequestHeader(HttpConstants.TUS_EXTENSION))
-                Timber.w("  Upload-Length: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_LENGTH))
-                Timber.w("  Upload-Metadata: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_METADATA))
-                Timber.w("  Content-Type: %s", postMethod.getRequestHeader(HttpConstants.CONTENT_TYPE_HEADER))
-                Timber.w("  Content-Length: %d", postBody.contentLength())
-                if (useCreationWithUpload && (firstChunkSize ?: 0L) > 0L) {
-                    Timber.w("  Upload-Offset: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_OFFSET))
-                }
+            if (status == HttpConstants.HTTP_PRECONDITION_FAILED) {
+                logPreconditionFailure(postMethod, creationRequestBody.body)
             }
 
-            if (isSuccess(status)) {
-                val locationHeader = postMethod.getResponseHeader(HttpConstants.LOCATION_HEADER)
-                    ?: postMethod.getResponseHeader(HttpConstants.LOCATION_HEADER_LOWER)
-                val base = URL(postMethod.getFinalUrl().toString())
-                val resolved = resolveLocationToAbsolute(locationHeader, base)
-
-                val offsetHeader = postMethod.getResponseHeader(HttpConstants.UPLOAD_OFFSET)
-                val offset = offsetHeader?.toLongOrNull() ?: 0L
-
-                if (resolved != null) {
-                    Timber.d("TUS upload resource created: %s (offset=%d)", resolved, offset)
-                    RemoteOperationResult<CreationResult>(ResultCode.OK).apply {
-                        data = CreationResult(resolved, offset)
-                    }
-                } else {
-                    Timber.e("Location header is missing in TUS creation response")
-                    RemoteOperationResult<CreationResult>(IllegalStateException("Location header missing")).apply {
-                        data = null
-                    }
-                }
-            } else {
-                Timber.w("TUS creation failed with status: %d", status)
-                RemoteOperationResult<CreationResult>(postMethod).apply { data = null }
+            buildCreationResult(status, postMethod)
+        } catch (e: Exception) {
+            val result = RemoteOperationResult<CreationResult>(e)
+            Timber.e(e, "TUS creation operation failed")
+            result
+        } finally {
+            try {
+                creationUploadFile?.close()
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to close TUS creation upload file")
             }
-    } catch (e: Exception) {
-        val result = RemoteOperationResult<CreationResult>(e)
-        Timber.e(e, "TUS creation operation failed")
-        result
+        }
     }
+
+    private fun resolveTargetFileUrl(client: OpenCloudClient): String {
+        if (!tusUrl.isNullOrBlank()) {
+            return tusUrl
+        }
+
+        val baseCollection = (collectionUrlOverride
+            ?: client.userFilesWebDavUri.toString()).trim()
+        val resolvedCollection = buildCollectionUrl(baseCollection, remotePath).trimEnd('/')
+        Timber.d("TUS resolved collection: %s", resolvedCollection)
+        return resolvedCollection
+    }
+
+    private fun buildCreationRequestBody(): CreationRequestBody =
+        if (shouldUseCreationWithUpload()) {
+            val raf = RandomAccessFile(file, "r")
+            val channel: FileChannel = raf.channel
+            CreationRequestBody(
+                body = ChunkFromFileRequestBody(
+                    file = file,
+                    contentType = HttpConstants.CONTENT_TYPE_OFFSET_OCTET_STREAM.toMediaTypeOrNull(),
+                    channel = channel,
+                    chunkSize = firstChunkSize!!
+                ),
+                fileToClose = raf
+            )
+        } else {
+            CreationRequestBody(
+                body = ByteArray(0).toRequestBody(null),
+                fileToClose = null
+            )
+        }
+
+    private fun configureCreationRequest(postMethod: PostMethod) {
+        postMethod.setRequestHeader(HttpConstants.TUS_RESUMABLE, "1.0.0")
+        postMethod.setRequestHeader(HttpConstants.UPLOAD_LENGTH, file.length().toString())
+        postMethod.setRequestHeader(HttpConstants.CONTENT_TYPE_HEADER, HttpConstants.CONTENT_TYPE_OFFSET_OCTET_STREAM)
+        postMethod.setRequestHeader(HttpConstants.TUS_EXTENSION, tusExtensionHeader())
+
+        val allMetadata = metadata.toMutableMap()
+        allMetadata.putIfAbsent("filename", remotePath.substringAfterLast('/'))
+        allMetadata.putIfAbsent("mtime", (file.lastModified() / 1000).toString())
+
+        if (allMetadata.isNotEmpty()) {
+            postMethod.setRequestHeader(HttpConstants.UPLOAD_METADATA, encodeTusMetadata(allMetadata))
+        }
+
+        if (shouldUseCreationWithUpload()) {
+            postMethod.setRequestHeader(HttpConstants.UPLOAD_OFFSET, "0")
+        }
+    }
+
+    private fun tusExtensionHeader(): String =
+        if (shouldUseCreationWithUpload()) {
+            "creation,creation-with-upload"
+        } else {
+            "creation"
+        }
+
+    private fun buildCreationResult(status: Int, postMethod: PostMethod): RemoteOperationResult<CreationResult> =
+        if (isSuccess(status)) {
+            buildSuccessfulCreationResult(postMethod)
+        } else {
+            Timber.w("TUS creation failed with status: %d", status)
+            RemoteOperationResult<CreationResult>(postMethod).apply { data = null }
+        }
+
+    private fun buildSuccessfulCreationResult(postMethod: PostMethod): RemoteOperationResult<CreationResult> {
+        val locationHeader = postMethod.getResponseHeader(HttpConstants.LOCATION_HEADER)
+            ?: postMethod.getResponseHeader(HttpConstants.LOCATION_HEADER_LOWER)
+        val base = URL(postMethod.getFinalUrl().toString())
+        val resolved = resolveLocationToAbsolute(locationHeader, base)
+
+        val offsetHeader = postMethod.getResponseHeader(HttpConstants.UPLOAD_OFFSET)
+        val offset = offsetHeader?.toLongOrNull() ?: 0L
+
+        return if (resolved != null) {
+            Timber.d("TUS upload resource created: %s (offset=%d)", resolved, offset)
+            RemoteOperationResult<CreationResult>(ResultCode.OK).apply {
+                data = CreationResult(resolved, offset)
+            }
+        } else {
+            Timber.e("Location header is missing in TUS creation response")
+            RemoteOperationResult<CreationResult>(IllegalStateException("Location header missing")).apply {
+                data = null
+            }
+        }
+    }
+
+    private fun logCreationFailure(
+        status: Int,
+        targetFileUrl: String,
+        postMethod: PostMethod,
+        client: OpenCloudClient
+    ) {
+        Timber.w("TUS Creation failed - Status: %d", status)
+        Timber.w("  Target URL: %s", targetFileUrl)
+        Timber.w("  Collection Override: %s", collectionUrlOverride)
+        Timber.w("  User Files WebDAV: %s", client.userFilesWebDavUri)
+        Timber.w("  Remote Path: %s", remotePath)
+        Timber.w("  File Size: %d bytes", file.length())
+        Timber.w("  Tus-Resumable: %s", postMethod.getRequestHeader(HttpConstants.TUS_RESUMABLE))
+        Timber.w("  Upload-Length: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_LENGTH))
+        Timber.w("  Upload-Metadata: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_METADATA))
+    }
+
+    private fun logPreconditionFailure(postMethod: PostMethod, postBody: RequestBody) {
+        Timber.w("HTTP 412 Precondition Failed - Request headers:")
+        Timber.w("  Tus-Resumable: %s", postMethod.getRequestHeader(HttpConstants.TUS_RESUMABLE))
+        Timber.w("  Tus-Extension: %s", postMethod.getRequestHeader(HttpConstants.TUS_EXTENSION))
+        Timber.w("  Upload-Length: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_LENGTH))
+        Timber.w("  Upload-Metadata: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_METADATA))
+        Timber.w("  Content-Type: %s", postMethod.getRequestHeader(HttpConstants.CONTENT_TYPE_HEADER))
+        Timber.w("  Content-Length: %d", postBody.contentLength())
+        if (shouldUseCreationWithUpload()) {
+            Timber.w("  Upload-Offset: %s", postMethod.getRequestHeader(HttpConstants.UPLOAD_OFFSET))
+        }
+    }
+
+    private fun shouldUseCreationWithUpload(): Boolean =
+        useCreationWithUpload && (firstChunkSize ?: 0L) > 0L
 
     private fun isSuccess(status: Int) =
         status.isOneOf(HttpConstants.HTTP_CREATED, HttpConstants.HTTP_OK)
@@ -182,7 +225,6 @@ class CreateTusUploadRemoteOperation(
             null
         }
     }
-
 
 
     private fun buildCollectionUrl(base: String, remotePath: String): String {

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/files/tus/TusIntegrationTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/resources/files/tus/TusIntegrationTest.kt
@@ -8,12 +8,14 @@ import eu.opencloud.android.lib.common.OpenCloudAccount
 import eu.opencloud.android.lib.common.OpenCloudClient
 import eu.opencloud.android.lib.common.accounts.AccountUtils
 import eu.opencloud.android.lib.common.authentication.OpenCloudCredentialsFactory
+import eu.opencloud.android.lib.common.network.ChunkFromFileRequestBody
 import eu.opencloud.android.lib.common.operations.RemoteOperationResult
 import eu.opencloud.android.lib.resources.files.tus.CreateTusUploadRemoteOperation.Base64Encoder
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -21,6 +23,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.ClosedChannelException
 import java.util.Base64
 
 @RunWith(RobolectricTestRunner::class)
@@ -245,6 +249,118 @@ class TusIntegrationTest {
         // creation-with-upload sends Content-Type and Content-Length for the chunk
         assertEquals("application/offset+octet-stream", postReq.getHeader("Content-Type"))
         assertEquals(firstChunkSize.toString(), postReq.getHeader("Content-Length"))
+        assertTrue("Local file should be deletable after TUS creation-with-upload", localFile.delete())
+    }
+
+    @Test
+    fun chunk_body_propagates_channel_failures() {
+        val localFile = File.createTempFile("tus", ".bin").apply {
+            writeBytes(ByteArray(10) { it.toByte() })
+        }
+        val raf = RandomAccessFile(localFile, "r")
+        val body = ChunkFromFileRequestBody(
+            file = localFile,
+            contentType = null,
+            channel = raf.channel,
+            chunkSize = 5
+        )
+
+        raf.close()
+
+        try {
+            body.writeTo(Buffer())
+            fail("Expected closed channel failure")
+        } catch (expected: ClosedChannelException) {
+            // Expected failure must reach OkHttp so the upload can fail.
+        } finally {
+            localFile.delete()
+        }
+    }
+
+    @Test
+    fun creation_with_upload_propagates_body_failure() {
+        val client = newClient()
+        val collectionPath = "/remote.php/dav/uploads/$userId"
+        val localFile = File.createTempFile("tus", ".bin").apply {
+            writeBytes(ByteArray(100) { it.toByte() })
+        }
+
+        // Even with a successful 201 from the server, the body must be readable.
+        // The server response is irrelevant here: we will delete the file
+        // before the body can be written, forcing a channel read failure that
+        // must surface as a non-success result code.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(201)
+                .addHeader("Tus-Resumable", "1.0.0")
+                .addHeader("Location", "$collectionPath/UPLD-FAIL")
+        )
+
+        val create = CreateTusUploadRemoteOperation(
+            file = localFile,
+            remotePath = "/test-with-data-fail.bin",
+            mimetype = "application/octet-stream",
+            metadata = mapOf("filename" to "test-with-data-fail.bin"),
+            useCreationWithUpload = true,
+            firstChunkSize = 50L,
+            tusUrl = null,
+            collectionUrlOverride = server.url(collectionPath).toString(),
+            base64Encoder = object : Base64Encoder {
+                override fun encode(bytes: ByteArray): String =
+                    Base64.getEncoder().encodeToString(bytes)
+            }
+        )
+
+        // Delete the local file so the channel read fails when OkHttp tries to
+        // stream the first chunk to the server. This simulates disk errors,
+        // removed files, or revoked permissions mid-upload.
+        assertTrue(localFile.delete())
+
+        val createResult = create.execute(client)
+        assertFalse("Create must not succeed when the body cannot be read", createResult.isSuccess)
+        assertNotNull("Failure result must carry the underlying exception", createResult.exception)
+        assertNotEquals(
+            "Failure result code must not be OK",
+            RemoteOperationResult.ResultCode.OK,
+            createResult.code
+        )
+    }
+
+    @Test
+    fun creation_only_does_not_open_file() {
+        val client = newClient()
+        val collectionPath = "/remote.php/dav/uploads/$userId"
+        val localFile = File.createTempFile("tus", ".bin").apply {
+            writeBytes(ByteArray(10) { 1 })
+        }
+        val locationPath = "$collectionPath/UPLD-CREATION-ONLY"
+
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(201)
+                .addHeader("Tus-Resumable", "1.0.0")
+                .addHeader("Location", locationPath)
+        )
+
+        val create = CreateTusUploadRemoteOperation(
+            file = localFile,
+            remotePath = "/test.bin",
+            mimetype = "application/octet-stream",
+            metadata = mapOf("filename" to "test.bin"),
+            useCreationWithUpload = false,
+            firstChunkSize = null,
+            tusUrl = null,
+            collectionUrlOverride = server.url(collectionPath).toString(),
+            base64Encoder = object : Base64Encoder {
+                override fun encode(bytes: ByteArray): String =
+                    Base64.getEncoder().encodeToString(bytes)
+            }
+        )
+
+        val createResult = create.execute(client)
+        assertTrue("Creation-only POST must succeed", createResult.isSuccess)
+        // The finally block must be a no-op when no file was opened.
+        assertTrue("Local file must remain deletable after creation-only POST", localFile.delete())
     }
 
     @Test


### PR DESCRIPTION
- Propagate request body read failures during TUS uploads so OkHttp can abort the request and the server (tusd writeChunk) returns a meaningful error instead of treating a partial body as success. Previously, exceptions raised while streaming the request body were silently logged, leaving the client to believe the upload completed correctly.

- Close the file handle used for creation-with-upload after the request completes. The previous code opened a RandomAccessFile and never closed it, leaking file descriptors and blocking file deletion on Windows.

- Refactor CreateTusUploadRemoteOperation.run for readability (LongMethod detekt).

- Add tests for body error propagation, file handle cleanup, and the creation-only path.