### PR TITLE
PrivacyPolicyActivity: log unhandled non-http(s) URLs as warning

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/settings/privacypolicy/PrivacyPolicyActivity.kt
@@ -104,6 +104,7 @@ class PrivacyPolicyActivity : AppCompatActivity() {
                     val url = request?.url ?: return false
                     val scheme = url.scheme?.lowercase()
                     if (scheme == "http" || scheme == "https") return false
+
                     return try {
                         val intent = Intent(Intent.ACTION_VIEW, url).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -111,7 +112,7 @@ class PrivacyPolicyActivity : AppCompatActivity() {
                         startActivity(intent)
                         true
                     } catch (e: ActivityNotFoundException) {
-                        Timber.d(e, "No activity to handle %s", url)
+                        Timber.w(e, "No Activity found to handle privacy policy URL")
                         false
                     }
                 }


### PR DESCRIPTION
When the WebView's shouldOverrideUrlLoading encounters a non-http(s) URL (e.g. mailto:, tel:) and no external app can handle it, the resulting ActivityNotFoundException is logged at debug level. Promote it to warn with a more descriptive message so user-visible fallback failures are visible in logs.

Split out from the original TUS upload body error fix to keep concerns focused.