### PR TITLE
Shares: Honor write/delete permissions inside shared folders

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -994,13 +994,18 @@ class MainFileListFragment : Fragment(),
      * Check whether the fab should be shown or hidden depending on the [FileListOption] and
      * the current folder displayed permissions
      *
-     * Show FAB when [FileListOption.ALL_FILES] and not picking a folder
-     * Hide FAB When [FileListOption.SHARED_BY_LINK], [FileListOption.AV_OFFLINE] or picking a folder
+     * Show FAB when [FileListOption.ALL_FILES], or when inside a sub-folder reached via
+     * [FileListOption.SHARED_BY_LINK] (i.e. a folder shared with the user in the Shares space)
+     * and the current folder grants add-file or add-subdirectory permission.
+     * Hide FAB at the flat-list roots ([FileListOption.SHARED_BY_LINK] root,
+     * [FileListOption.AV_OFFLINE]) or when picking a folder.
      *
      * @param newFileListOption new file list option to enable.
      */
     private fun showOrHideFab(newFileListOption: FileListOption, currentFolder: OCFile) {
-        if (!newFileListOption.isAllFiles() || isPickingAFolder() ||
+        val isFabSupportedView = newFileListOption.isAllFiles() ||
+                (newFileListOption.isSharedByLink() && currentFolder.remotePath != ROOT_PATH)
+        if (!isFabSupportedView || isPickingAFolder() ||
             (!currentFolder.hasAddFilePermission && !currentFolder.hasAddSubdirectoriesPermission)) {
             toggleFabVisibility(false)
         } else {

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListViewModel.kt
@@ -319,7 +319,8 @@ class MainFileListViewModel(
                     displaySelectAll = displaySelectAll,
                     displaySelectInverse = isMultiselection,
                     onlyAvailableOfflineFiles = fileListOption.value.isAvailableOffline(),
-                    onlySharedByLinkFiles = fileListOption.value.isSharedByLink(),
+                    onlySharedByLinkFiles = fileListOption.value.isSharedByLink() &&
+                            currentFolderDisplayed.value.remotePath == ROOT_PATH,
                     shareViaLinkAllowed = shareViaLinkAllowed,
                     shareWithUsersAllowed = shareWithUsersAllowed,
                     sendAllowed = sendAllowed,


### PR DESCRIPTION
The "Shares" bottom-bar tab navigates with FileListOption.SHARED_BY_LINK, which treated every screen under it as a flat list. As a result the FAB and the Remove/Rename/Move menu items were hidden even when standing inside a folder shared with full Create/Change/Delete permissions.

Restrict the flat-list assumption to the root: show the FAB inside SHARED_BY_LINK sub-folders when the folder grants add-file/subdirectory permission, and let onlySharedByLinkFiles flag only at the root so the file's own permissions gate Remove/Rename/Move.

Fixes #193