### PR TITLE
Fix: writable shared folders are read-only on mobile (no upload/delete)

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -994,13 +994,18 @@ class MainFileListFragment : Fragment(),
      * Check whether the fab should be shown or hidden depending on the [FileListOption] and
      * the current folder displayed permissions
      *
-     * Show FAB when [FileListOption.ALL_FILES] and not picking a folder
-     * Hide FAB When [FileListOption.SHARED_BY_LINK], [FileListOption.AV_OFFLINE] or picking a folder
+     * Show FAB when [FileListOption.ALL_FILES], or when browsing inside a shared folder
+     * (i.e. [FileListOption.SHARED_BY_LINK] and not at the root of the shares list), as long as the
+     * current folder grants the proper permissions and we are not picking a folder.
+     * Hide FAB at the root of [FileListOption.SHARED_BY_LINK], for [FileListOption.AV_OFFLINE],
+     * when picking a folder or when the current folder does not grant add permissions.
      *
      * @param newFileListOption new file list option to enable.
      */
     private fun showOrHideFab(newFileListOption: FileListOption, currentFolder: OCFile) {
-        if (!newFileListOption.isAllFiles() || isPickingAFolder() ||
+        val isBrowsingInsideSharedFolder = newFileListOption.isSharedByLink() && currentFolder.remotePath != ROOT_PATH
+        val fabAllowedForOption = newFileListOption.isAllFiles() || isBrowsingInsideSharedFolder
+        if (!fabAllowedForOption || isPickingAFolder() ||
             (!currentFolder.hasAddFilePermission && !currentFolder.hasAddSubdirectoriesPermission)) {
             toggleFabVisibility(false)
         } else {

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListViewModel.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListViewModel.kt
@@ -319,7 +319,8 @@ class MainFileListViewModel(
                     displaySelectAll = displaySelectAll,
                     displaySelectInverse = isMultiselection,
                     onlyAvailableOfflineFiles = fileListOption.value.isAvailableOffline(),
-                    onlySharedByLinkFiles = fileListOption.value.isSharedByLink(),
+                    onlySharedByLinkFiles = fileListOption.value.isSharedByLink() &&
+                            currentFolderDisplayed.value.remotePath == ROOT_PATH,
                     shareViaLinkAllowed = shareViaLinkAllowed,
                     shareWithUsersAllowed = shareWithUsersAllowed,
                     sendAllowed = sendAllowed,


### PR DESCRIPTION
## Summary

Fixes #193

When browsing a shared folder via the **Shares** (`SHARED_BY_LINK`) view, the upload/create FAB and the file context-menu actions (remove/move/rename/…) were unconditionally hidden, making writable shares effectively **read-only on mobile** — even when the share grants Create/Change/Delete permissions. The same folder works correctly in the web UI.

## Root cause

The app conflates the **root of the Shares list** with **browsing inside a shared folder**. The content loader already handles this distinction — `retrieveFlowForShareByLink` falls back to `retrieveFlowForAllFiles` when not at the shares root — but the FAB and menu-option logic did not honor it.

## Changes

- **`MainFileListFragment.showOrHideFab`**: show the FAB when browsing inside a shared folder (`SHARED_BY_LINK` and `remotePath != ROOT_PATH`), governed by the folder's add permissions, instead of only for `ALL_FILES`.
- **`MainFileListViewModel.filterMenuOptions`**: only treat files as "shared by link" (read-only) at the **root** of the shares list, so inside a shared folder the per-file permissions drive the available actions.

Root of the Shares list keeps its current read-only behavior; `AV_OFFLINE` is unchanged.

## Testing

Manual: share a folder between two users with full permissions, open it in the Android app under Shares → the `+` upload FAB and delete/move/rename actions now appear and work, matching the web UI.

> Note: I was unable to run a Gradle build in my environment (no Android SDK), so CI verification is appreciated.