### PR TITLE
Login: Keep the mTLS certificate when handling the OAuth redirect

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/extensions/ThrowableExt.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/extensions/ThrowableExt.kt
@@ -52,6 +52,7 @@ import eu.opencloud.android.domain.exceptions.ServerResponseTimeoutException
 import eu.opencloud.android.domain.exceptions.ServiceUnavailableException
 import eu.opencloud.android.domain.exceptions.SpecificForbiddenException
 import eu.opencloud.android.domain.exceptions.UnauthorizedException
+import eu.opencloud.android.domain.exceptions.UnhandledHttpCodeException
 import eu.opencloud.android.domain.exceptions.validation.FileNameException
 import java.util.Locale
 
@@ -98,6 +99,10 @@ fun Throwable.parseError(
             is ServiceUnavailableException -> resources.getString(R.string.service_unavailable)
             is SpecificForbiddenException -> resources.getString(R.string.uploads_view_upload_status_failed_permission_error)
             is UnauthorizedException -> resources.getString(R.string.auth_unauthorized)
+            // Naming the status beats "unknown error": it is the only clue the user can pass on to an admin.
+            is UnhandledHttpCodeException ->
+                if (httpCode > 0) resources.getString(R.string.error_http_code, httpCode)
+                else resources.getString(R.string.common_error_unknown)
             is NetworkErrorException -> resources.getString(R.string.network_error_message)
             is ResourceLockedException -> resources.getString(R.string.resource_locked_error_message)
             else -> resources.getString(R.string.common_error_unknown)

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/LoginActivity.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/LoginActivity.kt
@@ -68,6 +68,7 @@ import eu.opencloud.android.domain.exceptions.SSLErrorException
 import eu.opencloud.android.domain.exceptions.ServerNotReachableException
 import eu.opencloud.android.domain.exceptions.SpecificForbiddenException
 import eu.opencloud.android.domain.exceptions.UnauthorizedException
+import eu.opencloud.android.domain.exceptions.UnhandledHttpCodeException
 import eu.opencloud.android.domain.server.model.ServerInfo
 import eu.opencloud.android.extensions.checkPasscodeEnforced
 import eu.opencloud.android.extensions.goToUrl
@@ -77,6 +78,7 @@ import eu.opencloud.android.extensions.showErrorInToast
 import eu.opencloud.android.extensions.showMessageInSnackbar
 import eu.opencloud.android.lib.common.accounts.AccountTypeUtils
 import eu.opencloud.android.lib.common.accounts.AccountUtils
+import eu.opencloud.android.lib.common.http.HttpConstants
 import eu.opencloud.android.lib.common.network.CertificateCombinedException
 import eu.opencloud.android.presentation.authentication.AccountUtils.getAccounts
 import eu.opencloud.android.presentation.authentication.AccountUtils.getUsernameOfAccount
@@ -122,6 +124,16 @@ private const val KEYCHAIN_NO_PORT = -1
 // PopupMenu item ids for the wizard "Connection…" menu.
 private const val MENU_SET_CERT = 1
 private const val MENU_CLEAR_CERT = 2
+
+// nginx answers a missing or invalid client certificate with 400, or with its own 495/496 when it is
+// configured to surface them. Apache, IIS and Cloudflare answer 403, handled through ForbiddenException.
+private const val HTTP_NGINX_SSL_CERTIFICATE_ERROR = 495
+private const val HTTP_NGINX_SSL_CERTIFICATE_REQUIRED = 496
+private val CLIENT_CERT_REJECTION_HTTP_CODES = setOf(
+    HttpConstants.HTTP_BAD_REQUEST,
+    HTTP_NGINX_SSL_CERTIFICATE_ERROR,
+    HTTP_NGINX_SSL_CERTIFICATE_REQUIRED,
+)
 
 class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrustedCertListener, SecurityEnforced {
 
@@ -692,9 +704,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
                 setCompoundDrawablesWithIntrinsicBounds(R.drawable.common_error, 0, 0, 0)
             }
 
-            // A 403 on the status endpoint during login is nearly always a rejected or missing client
-            // certificate (the generic "Permission error" wording is useless here).
-            uiResult.error is ForbiddenException || uiResult.error is SpecificForbiddenException -> binding.serverStatusText.run {
+            isPossibleClientCertRejection(uiResult.error) -> binding.serverStatusText.run {
                 text = getString(R.string.auth_forbidden_check_client_cert)
                 setCompoundDrawablesWithIntrinsicBounds(R.drawable.common_error, 0, 0, 0)
             }
@@ -706,6 +716,17 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         }
         binding.serverStatusText.isVisible = true
         showOrHideBasicAuthFields(shouldBeVisible = false)
+    }
+
+    /**
+     * A server behind mTLS turns down a request without an accepted client certificate in several ways:
+     * Apache, IIS and Cloudflare answer 403, nginx answers 400 (or 495/496). During login none of these
+     * means anything else in practice, so point at the certificate rather than at a generic HTTP error.
+     */
+    private fun isPossibleClientCertRejection(error: Throwable?): Boolean = when (error) {
+        is ForbiddenException, is SpecificForbiddenException -> true
+        is UnhandledHttpCodeException -> error.httpCode in CLIENT_CERT_REJECTION_HTTP_CODES
+        else -> false
     }
 
     private fun loginIsSuccess(uiResult: UIResult.Success<String>) {

--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/LoginActivity.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/authentication/LoginActivity.kt
@@ -60,11 +60,13 @@ import eu.opencloud.android.databinding.AccountSetupBinding
 import eu.opencloud.android.domain.authentication.oauth.model.ClientRegistrationInfo
 import eu.opencloud.android.domain.authentication.oauth.model.ResponseType
 import eu.opencloud.android.domain.authentication.oauth.model.TokenRequest
+import eu.opencloud.android.domain.exceptions.ForbiddenException
 import eu.opencloud.android.domain.exceptions.NoNetworkConnectionException
 import eu.opencloud.android.domain.exceptions.OpencloudVersionNotSupportedException
 import eu.opencloud.android.domain.exceptions.SSLErrorCode
 import eu.opencloud.android.domain.exceptions.SSLErrorException
 import eu.opencloud.android.domain.exceptions.ServerNotReachableException
+import eu.opencloud.android.domain.exceptions.SpecificForbiddenException
 import eu.opencloud.android.domain.exceptions.UnauthorizedException
 import eu.opencloud.android.domain.server.model.ServerInfo
 import eu.opencloud.android.extensions.checkPasscodeEnforced
@@ -112,6 +114,7 @@ private const val KEY_AUTH_OIDC_SUPPORTED = "KEY_AUTH_OIDC_SUPPORTED"
 private const val KEY_AUTH_LOGIN_ACTION = "KEY_AUTH_LOGIN_ACTION"
 private const val KEY_AUTH_USER_ACCOUNT = "KEY_AUTH_USER_ACCOUNT"
 private const val KEY_AUTH_MTLS_CERT_ALIAS = "KEY_AUTH_MTLS_CERT_ALIAS"
+private const val KEY_AUTH_MTLS_CERT_ALIAS_CHANGED = "KEY_AUTH_MTLS_CERT_ALIAS_CHANGED"
 
 // KeyChain.choosePrivateKeyAlias: -1 means no port constraint on the host hint.
 private const val KEYCHAIN_NO_PORT = -1
@@ -129,6 +132,9 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
 
     // Alias (from the Android KeyChain) of the client certificate to present for mTLS during login.
     private var clientCertAlias: String? = null
+
+    /** True once the user picked or removed a certificate on this screen, so null means "removed". */
+    private var clientCertAliasChangedByUser = false
 
     private var loginAction: Byte = ACTION_CREATE
     private var authTokenType: String? = null
@@ -166,8 +172,18 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         authTokenType = intent.getStringExtra(KEY_AUTH_TOKEN_TYPE)
         userAccount = intent.getParcelableExtra(EXTRA_ACCOUNT)
 
+        // The OAuth redirect intent comes from the browser and carries no extras, so loginAction and
+        // userAccount read above are wrong on the instance that handles it: they default to "create a
+        // new account". Restore the persisted auth state here, before anything downstream reads them,
+        // in particular restoreClientCertAlias() — otherwise the mTLS certificate bound to the account
+        // is never loaded and the /status.php request below goes out without a client certificate.
+        val isOAuthRedirect = isOAuthRedirectIntent(intent)
+        if (isOAuthRedirect && savedInstanceState == null) {
+            restoreAuthState()
+        }
+
         // Get values from savedInstanceState
-        if (savedInstanceState == null && authTokenType == null && userAccount != null) {
+        if (savedInstanceState == null && authTokenType == null && userAccount != null && !isOAuthRedirect) {
             authenticationViewModel.supportsOAuth2((userAccount as Account).name)
         } else if (savedInstanceState != null) {
             authTokenType = savedInstanceState.getString(KEY_AUTH_TOKEN_TYPE)
@@ -202,7 +218,15 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         }
 
         if (savedInstanceState == null) {
-            if (userAccount != null) {
+            if (isOAuthRedirect) {
+                // serverBaseUrl already came from the restored auth state. Deliberately skip
+                // getBaseUrl(): its observer calls checkOcServer(), which would race with the
+                // redirect handling at the end of onCreate. Fill the url field so the screen stays
+                // usable if the flow below fails.
+                if (::serverBaseUrl.isInitialized) {
+                    binding.hostUrlInput.setText(serverBaseUrl)
+                }
+            } else if (userAccount != null) {
                 authenticationViewModel.getBaseUrl((userAccount as Account).name)
             } else {
                 serverBaseUrl = getString(R.string.server_url).trim()
@@ -259,23 +283,39 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
 
         initLiveDataObservers()
 
-        if (intent.data != null && (intent.data?.getQueryParameter("code") != null || intent.data?.getQueryParameter("error") != null)) {
-            if (savedInstanceState == null) {
-                restoreAuthState()
-            }
-            if (authenticationViewModel.serverInfo.value?.peekContent()?.getStoredData() == null
-                && ::serverBaseUrl.isInitialized && serverBaseUrl.isNotEmpty()) {
-                // Process death: serverInfo is gone. Re-fetch it before processing the OAuth response.
-                // Store the intent as pending — getServerInfoIsSuccess will process it via checkServerType bypass.
-                pendingAuthorizationIntent = intent
-                authenticationViewModel.getServerInfo(serverBaseUrl)
-            } else {
-                handleGetAuthorizationCodeResponse(intent)
-            }
+        if (isOAuthRedirect) {
+            processOAuthRedirect()
         }
+    }
 
-        // Note: pendingAuthorizationIntent is processed in checkServerType() after
-        // getServerInfo() completes (process death recovery flow).
+    /**
+     * Processes the OAuth redirect intent once the UI and the observers are in place: exchanges the
+     * authorization code, or re-fetches the server info first when the process was killed while the
+     * browser was in front.
+     *
+     * Note: pendingAuthorizationIntent is processed in checkServerType() after getServerInfo()
+     * completes (process death recovery flow).
+     */
+    private fun processOAuthRedirect() {
+        val haveServerBaseUrl = ::serverBaseUrl.isInitialized && serverBaseUrl.isNotEmpty()
+        if (!haveServerBaseUrl) {
+            // No persisted auth state, so there is no server to exchange the code against.
+            // Fail visibly instead of crashing later on an uninitialized serverBaseUrl.
+            Timber.e("OAuth redirect received but no server base url was persisted")
+            clearAuthState()
+            binding.serverStatusText.run {
+                text = getString(R.string.auth_oauth_error)
+                setCompoundDrawablesWithIntrinsicBounds(R.drawable.common_error, 0, 0, 0)
+                isVisible = true
+            }
+        } else if (authenticationViewModel.serverInfo.value?.peekContent()?.getStoredData() == null) {
+            // Process death: serverInfo is gone. Re-fetch it before processing the OAuth response.
+            // Store the intent as pending — getServerInfoIsSuccess will process it via checkServerType bypass.
+            pendingAuthorizationIntent = intent
+            authenticationViewModel.getServerInfo(serverBaseUrl)
+        } else {
+            handleGetAuthorizationCodeResponse(intent)
+        }
     }
 
     /**
@@ -285,16 +325,26 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
      * account exists.
      */
     private fun restoreClientCertAlias(savedInstanceState: Bundle?) {
-        clientCertAlias = when {
-            savedInstanceState != null -> savedInstanceState.getString(KEY_AUTH_MTLS_CERT_ALIAS)
-            loginAction != ACTION_CREATE -> userAccount?.let {
+        clientCertAliasChangedByUser =
+            savedInstanceState?.getBoolean(KEY_AUTH_MTLS_CERT_ALIAS_CHANGED) ?: false
+        clientCertAlias = if (savedInstanceState != null) {
+            savedInstanceState.getString(KEY_AUTH_MTLS_CERT_ALIAS)
+        } else {
+            // Keyed on userAccount rather than loginAction: on the OAuth redirect leg the account is
+            // recovered from the persisted auth state, and keying on loginAction there used to drop
+            // the certificate. A fresh login has no account and correctly resolves to null.
+            userAccount?.let {
                 AccountManager.get(this).getUserData(it, AccountUtils.Constants.KEY_MTLS_CERT_ALIAS)
             }
-            else -> null
         }
         clientManager.loginClientCertAlias = clientCertAlias
         updateClientCertStatus()
     }
+
+    /** An OAuth redirect is an intent whose data carries either an authorization code or an error. */
+    private fun isOAuthRedirectIntent(intent: Intent): Boolean =
+        intent.data != null &&
+                (intent.data?.getQueryParameter("code") != null || intent.data?.getQueryParameter("error") != null)
 
     /**
      * If this onCreate is an OAuth redirect, either forward it to the existing instance
@@ -303,8 +353,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
      * @return true if onCreate should return early (redirect was forwarded).
      */
     private fun handleOAuthRedirectOnCreate(): Boolean {
-        val hasOAuthData = intent.data != null &&
-            (intent.data?.getQueryParameter("code") != null || intent.data?.getQueryParameter("error") != null)
+        val hasOAuthData = isOAuthRedirectIntent(intent)
 
         if (hasOAuthData) {
             Timber.d("OAuth redirect detected with code or error parameter")
@@ -609,6 +658,21 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
 
     private fun getServerInfoIsError(uiResult: UIResult.Error<ServerInfo>) {
         updateCenteredRefreshButtonVisibility(shouldBeVisible = true)
+
+        // Failing here on the OAuth return leg strands the flow. The authorization code is single-use
+        // and short-lived, so it is already dead: drop it instead of letting checkServerType() replay
+        // it on the next attempt (which would fail with a misleading authorization error), and drop
+        // the persisted auth state so a retry starts a clean browser round trip.
+        if (pendingAuthorizationIntent != null) {
+            Timber.w("Server check failed while handling the OAuth redirect; discarding the authorization code")
+            pendingAuthorizationIntent = null
+            clearAuthState()
+        }
+        // Keep the screen recoverable: the redirect instance may have an empty url field.
+        if (binding.hostUrlInput.text.isNullOrBlank() && ::serverBaseUrl.isInitialized && serverBaseUrl.isNotEmpty()) {
+            binding.hostUrlInput.setText(serverBaseUrl)
+        }
+
         when {
             uiResult.error is CertificateCombinedException ->
                 showUntrustedCertDialog(uiResult.error)
@@ -625,6 +689,13 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
 
             uiResult.error is SSLErrorException && uiResult.error.code == SSLErrorCode.NOT_HTTP_ALLOWED -> binding.serverStatusText.run {
                 text = getString(R.string.ssl_connection_not_secure)
+                setCompoundDrawablesWithIntrinsicBounds(R.drawable.common_error, 0, 0, 0)
+            }
+
+            // A 403 on the status endpoint during login is nearly always a rejected or missing client
+            // certificate (the generic "Permission error" wording is useless here).
+            uiResult.error is ForbiddenException || uiResult.error is SpecificForbiddenException -> binding.serverStatusText.run {
+                text = getString(R.string.auth_forbidden_check_client_cert)
                 setCompoundDrawablesWithIntrinsicBounds(R.drawable.common_error, 0, 0, 0)
             }
 
@@ -665,8 +736,13 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         }
 
         // Persist the mTLS client certificate chosen during login to the account, then clear the
-        // login-time transient so it does not leak into later anonymous clients.
-        am.setUserData(account, AccountUtils.Constants.KEY_MTLS_CERT_ALIAS, clientCertAlias?.takeIf { it.isNotBlank() })
+        // login-time transient so it does not leak into later anonymous clients. Only write when this
+        // screen actually holds a certificate or the user explicitly changed it: a re-login instance
+        // that failed to resolve the account's alias must not silently wipe it, which would break
+        // every subsequent connection and leave reinstalling as the only way out.
+        if (clientCertAlias != null || clientCertAliasChangedByUser || loginAction == ACTION_CREATE) {
+            am.setUserData(account, AccountUtils.Constants.KEY_MTLS_CERT_ALIAS, clientCertAlias?.takeIf { it.isNotBlank() })
+        }
         clientManager.loginClientCertAlias = null
 
         authenticationViewModel.discoverAccount(accountName = accountName, discoveryNeeded = loginAction == ACTION_CREATE)
@@ -1144,6 +1220,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         // Null = user cancelled the picker; keep the current selection.
         if (alias == null) return
         clientCertAlias = alias
+        clientCertAliasChangedByUser = true
         clientManager.loginClientCertAlias = alias
         updateClientCertStatus()
     }
@@ -1193,6 +1270,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
 
     private fun clearClientCert() {
         clientCertAlias = null
+        clientCertAliasChangedByUser = true
         clientManager.loginClientCertAlias = null
         updateClientCertStatus()
     }
@@ -1208,6 +1286,7 @@ class LoginActivity : AppCompatActivity(), SslUntrustedCertDialog.OnSslUntrusted
         outState.putString(KEY_CODE_CHALLENGE, authenticationViewModel.codeChallenge)
         outState.putString(KEY_OIDC_STATE, authenticationViewModel.oidcState)
         outState.putString(KEY_AUTH_MTLS_CERT_ALIAS, clientCertAlias)
+        outState.putBoolean(KEY_AUTH_MTLS_CERT_ALIAS_CHANGED, clientCertAliasChangedByUser)
     }
 
     override fun finish() {

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -377,6 +377,7 @@
     <string name="auth_expired_basic_auth_toast">Please enter the current password</string>
     <string name="auth_connecting_auth_server">Connecting to authentication server …</string>
     <string name="auth_unsupported_auth_method">The server does not support this authentication method</string>
+    <string name="auth_forbidden_check_client_cert">Server refused the connection. If it requires a client certificate, check the one selected under Connection.</string>
     <string name="auth_fail_get_user_name">Your server is not returning a correct user ID. Please contact an administrator.</string>
     <string name="auth_can_not_auth_against_server">Cannot authenticate to this server</string>
     <string name="auth_account_does_not_exist">Account does not exist in the device yet</string>

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@
     <string name="common_loading">Loading…</string>
     <string name="common_unknown">unknown</string>
     <string name="common_error_unknown">unknown error</string>
+    <string name="error_http_code">Server returned an unexpected error (HTTP %1$d)</string>
     <string name="common_pending">Pending</string>
     <string name="common_important">Important</string>
     <string name="change_password">Change password</string>

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/status/GetRemoteStatusOperation.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/status/GetRemoteStatusOperation.kt
@@ -61,7 +61,9 @@ class GetRemoteStatusOperation : RemoteOperation<RemoteServerInfo>() {
             val requester = StatusRequester()
             val requestResult = requester.request(baseUrl, client)
             val result = requester.handleRequestResult(requestResult, baseUrl)
-            updateClientBaseUrl(client, result.data.baseUrl)
+            // data is only set on success; dereferencing it unconditionally turned every failed
+            // status check into an opaque NPE result instead of the actual HTTP error.
+            result.data?.let { updateClientBaseUrl(client, it.baseUrl) }
             return result
         } catch (e: JSONException) {
             Timber.e(e, "JSON is not correct")

--- a/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/status/StatusRequester.kt
+++ b/opencloudComLibrary/src/main/java/eu/opencloud/android/lib/resources/status/StatusRequester.kt
@@ -91,10 +91,14 @@ internal class StatusRequester {
         requestResult: RequestResult,
         baseUrl: String
     ): RemoteOperationResult<RemoteServerInfo> {
+        // Check the status code before touching the body. A failed response is very often not JSON at
+        // all (a reverse proxy error page, an mTLS rejection, a captive portal, an empty body), and
+        // parsing it first would throw and hide the real HTTP error behind INSTANCE_NOT_CONFIGURED.
+        if (!requestResult.status.isSuccess()) {
+            return RemoteOperationResult(requestResult.getMethod)
+        }
         val respJSON = JSONObject(requestResult.getMethod.getResponseBodyAsString())
-        return if (!requestResult.status.isSuccess()) {
-            RemoteOperationResult(requestResult.getMethod)
-        } else if (!respJSON.getBoolean(NODE_INSTALLED)) {
+        return if (!respJSON.getBoolean(NODE_INSTALLED)) {
             RemoteOperationResult(RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED)
         } else {
             val ocVersion = OpenCloudVersion(respJSON.getString(NODE_VERSION), respJSON.getString(NODE_PRODUCTVERSION))

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/StatusRequesterHandleResultTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/StatusRequesterHandleResultTest.kt
@@ -1,0 +1,120 @@
+/* openCloud Android Library is available under MIT license
+*   Copyright (C) 2021 ownCloud GmbH.
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software and associated documentation files (the "Software"), to deal
+*   in the Software without restriction, including without limitation the rights
+*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*   copies of the Software, and to permit persons to whom the Software is
+*   furnished to do so, subject to the following conditions:
+*
+*   The above copyright notice and this permission notice shall be included in
+*   all copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+*   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+*   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+*   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+*   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+*   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+*   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+*   THE SOFTWARE.
+*
+*/
+
+package eu.opencloud.android.lib
+
+import android.os.Build
+import eu.opencloud.android.lib.common.http.methods.nonwebdav.GetMethod
+import eu.opencloud.android.lib.common.operations.RemoteOperationResult
+import eu.opencloud.android.lib.resources.status.StatusRequester
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.URL
+
+/**
+ * The status endpoint is the first thing hit when adding or re-authenticating an account, so the
+ * failure it reports is the failure the user sees on the login screen. It used to parse the body as
+ * JSON before looking at the status code, which turned every non-JSON error response into a bogus
+ * "malformed server configuration".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O], manifest = Config.NONE)
+class StatusRequesterHandleResultTest {
+
+    private val requester = StatusRequester()
+
+    @Test
+    fun `handle request result - ko - forbidden with an html body reports the http error`() {
+        val result = requester.handleRequestResult(requestResult(403, CLOUDFLARE_MTLS_ERROR_PAGE, HTML), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.FORBIDDEN, result.code)
+        assertEquals(403, result.httpCode)
+    }
+
+    @Test
+    fun `handle request result - ko - bad gateway with an html body reports the http error`() {
+        val result = requester.handleRequestResult(requestResult(502, "<html><body>Bad gateway</body></html>", HTML), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.UNHANDLED_HTTP_CODE, result.code)
+        assertEquals(502, result.httpCode)
+    }
+
+    @Test
+    fun `handle request result - ko - unauthorized with an empty body reports the http error`() {
+        val result = requester.handleRequestResult(requestResult(401, "", HTML), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.UNAUTHORIZED, result.code)
+    }
+
+    @Test
+    fun `handle request result - ko - not installed`() {
+        val body = """{"installed":false,"version":"10.0.0.0","productversion":"1.0.0"}"""
+
+        val result = requester.handleRequestResult(requestResult(200, body, JSON), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED, result.code)
+    }
+
+    @Test
+    fun `handle request result - ok - installed over https`() {
+        val body = """{"installed":true,"version":"10.0.0.0","productversion":"1.0.0"}"""
+
+        val result = requester.handleRequestResult(requestResult(200, body, JSON), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.OK_SSL, result.code)
+        assertEquals(BASE_URL, result.data.baseUrl)
+    }
+
+    private fun requestResult(code: Int, body: String, contentType: String): StatusRequester.RequestResult {
+        val url = URL(STATUS_URL)
+        val response = Response.Builder()
+            .request(Request.Builder().url(url).build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("")
+            .body(body.toResponseBody(contentType.toMediaType()))
+            .build()
+        val getMethod = GetMethod(url).apply { this.response = response }
+        return StatusRequester.RequestResult(getMethod, code, STATUS_URL)
+    }
+
+    companion object {
+        private const val BASE_URL = "https://cloud.somewhere.com"
+        private const val STATUS_URL = "$BASE_URL/status.php"
+        private const val HTML = "text/html"
+        private const val JSON = "application/json"
+
+        /** What Cloudflare returns when the client certificate is missing on an mTLS-protected host. */
+        private const val CLOUDFLARE_MTLS_ERROR_PAGE =
+            "<html><head><title>403 Forbidden</title></head><body>No required SSL certificate was sent</body></html>"
+    }
+}

--- a/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/StatusRequesterHandleResultTest.kt
+++ b/opencloudComLibrary/src/test/java/eu/opencloud/android/lib/StatusRequesterHandleResultTest.kt
@@ -61,6 +61,14 @@ class StatusRequesterHandleResultTest {
     }
 
     @Test
+    fun `handle request result - ko - bad request with an nginx no-certificate body reports the http error`() {
+        val result = requester.handleRequestResult(requestResult(400, NGINX_MTLS_ERROR_PAGE, HTML), BASE_URL)
+
+        assertEquals(RemoteOperationResult.ResultCode.UNHANDLED_HTTP_CODE, result.code)
+        assertEquals(400, result.httpCode)
+    }
+
+    @Test
     fun `handle request result - ko - bad gateway with an html body reports the http error`() {
         val result = requester.handleRequestResult(requestResult(502, "<html><body>Bad gateway</body></html>", HTML), BASE_URL)
 
@@ -116,5 +124,12 @@ class StatusRequesterHandleResultTest {
         /** What Cloudflare returns when the client certificate is missing on an mTLS-protected host. */
         private const val CLOUDFLARE_MTLS_ERROR_PAGE =
             "<html><head><title>403 Forbidden</title></head><body>No required SSL certificate was sent</body></html>"
+
+        /** What nginx returns in the same situation, verbatim from client.badssl.com. Note the unclosed <hr>. */
+        private const val NGINX_MTLS_ERROR_PAGE =
+            "<html>\n<head><title>400 No required SSL certificate was sent</title></head>\n" +
+                    "<body bgcolor=\"white\">\n<center><h1>400 Bad Request</h1></center>\n" +
+                    "<center>No required SSL certificate was sent</center>\n" +
+                    "<hr><center>nginx/1.10.3 (Ubuntu)</center>\n</body>\n</html>"
     }
 }

--- a/opencloudData/src/main/java/eu/opencloud/android/data/RemoteOperationHandler.kt
+++ b/opencloudData/src/main/java/eu/opencloud/android/data/RemoteOperationHandler.kt
@@ -109,7 +109,7 @@ private fun <T> handleRemoteOperationResult(
         RemoteOperationResult.ResultCode.ACCOUNT_NOT_NEW -> throw AccountNotNewException()
         RemoteOperationResult.ResultCode.ACCOUNT_NOT_THE_SAME -> throw AccountNotTheSameException()
         RemoteOperationResult.ResultCode.OK_REDIRECT_TO_NON_SECURE_CONNECTION -> throw RedirectToNonSecureException()
-        RemoteOperationResult.ResultCode.UNHANDLED_HTTP_CODE -> throw UnhandledHttpCodeException()
+        RemoteOperationResult.ResultCode.UNHANDLED_HTTP_CODE -> throw UnhandledHttpCodeException(remoteOperationResult.httpCode)
         RemoteOperationResult.ResultCode.UNKNOWN_ERROR -> throw UnknownErrorException()
         RemoteOperationResult.ResultCode.CANCELLED -> throw CancelledException()
         RemoteOperationResult.ResultCode.INVALID_LOCAL_FILE_NAME -> throw InvalidLocalFileNameException()

--- a/opencloudDomain/src/main/java/eu/opencloud/android/domain/exceptions/UnhandledHttpCodeException.kt
+++ b/opencloudDomain/src/main/java/eu/opencloud/android/domain/exceptions/UnhandledHttpCodeException.kt
@@ -21,4 +21,10 @@ package eu.opencloud.android.domain.exceptions
 
 import java.lang.Exception
 
-class UnhandledHttpCodeException : Exception()
+/**
+ * An HTTP status code we have no specific handling for. [httpCode] is 0 when the status is unknown.
+ *
+ * Note: the message is deliberately left null. Throwable.parseError() returns the message verbatim when
+ * there is one, which would show the raw server phrase to the user.
+ */
+class UnhandledHttpCodeException(val httpCode: Int = 0) : Exception()


### PR DESCRIPTION
## Problem

Re-authentication fails with **"Malformed server configuration"** on the login screen when the server requires a client certificate. Fresh login is unaffected, which is what makes this confusing. The account is then left unusable and reinstalling the app is the only way out.

Reproduced against a host behind Cloudflare mTLS, but it applies to any mTLS-protected instance.

## Root cause

When Android kills the app process while the OAuth Custom Tab is in the foreground, the browser redirect is handled by a brand new `LoginActivity` (`isTaskRoot == true`) rather than being forwarded to a live one via `onNewIntent`.

That redirect intent carries no extras, so `loginAction` fell back to `ACTION_CREATE` and `userAccount` was null. `restoreClientCertAlias()` ran *before* `restoreAuthState()`, so it took the "fresh login, no certificate" branch and set `clientManager.loginClientCertAlias = null`. The recovery `/status.php` request therefore went out with no client certificate and the server answered with an HTML 403.

`StatusRequester.handleRequestResult` parsed the body as JSON before looking at the status code, so the resulting `JSONException` was mapped to `INSTANCE_NOT_CONFIGURED`, surfacing as "Malformed server configuration" instead of the real HTTP error. The status-code branch below it was effectively dead code for any non-JSON body (proxy error pages, captive portals, empty bodies).

## Why it needed a reinstall

`getServerInfoIsError` only printed the message. It left `pendingAuthorizationIntent` armed with a now-dead single-use authorization code (so retrying produced a misleading "Unsuccessful authorization"), never called `clearAuthState()`, and left the url field empty. If the user then logged in fresh from that same screen, `loginIsSuccess` wrote `KEY_MTLS_CERT_ALIAS = null` onto the account, breaking every subsequent connection.

## Changes

**`LoginActivity`**
- Restore the persisted auth state at the top of `onCreate` on the redirect leg, before anything downstream reads `loginAction` or `userAccount`.
- Key `restoreClientCertAlias()` on `userAccount` rather than `loginAction`. Every launch that passes `EXTRA_ACCOUNT` also passes a non-CREATE `EXTRA_ACTION`, so this is behaviour-preserving for the existing paths and only changes the recovered-redirect case.
- Only overwrite the stored alias in `loginIsSuccess` when the user actually picked or removed a certificate on this screen (new `clientCertAliasChangedByUser` flag, persisted across configuration changes).
- On a failed server check during the redirect leg, drop the dead authorization code, clear the auth state and refill the url field so the screen stays recoverable.
- Report a 403 during login as a possible client certificate problem instead of the generic "Permission error", which is useless in this context.

**`StatusRequester` / `GetRemoteStatusOperation`**
- Check the HTTP status before parsing the body as JSON.
- Stop dereferencing `result.data.baseUrl` unconditionally: `data` is only set on success, so every failed status check turned into an opaque NPE result instead of the actual HTTP error.

The fix covers the whole recovery chain, not just `/status.php`: OIDC discovery, the token exchange and client registration all go through `ClientManager.getClientForAnonymousCredentials`, which applies `loginClientCertAlias` on both the new-client and reuse branches.

## Tests

New `StatusRequesterHandleResultTest` (5 cases) guards the regression:

| Response | Expected |
|---|---|
| 403 + HTML mTLS rejection page | `FORBIDDEN`, httpCode 403 |
| 502 + HTML | `UNHANDLED_HTTP_CODE`, httpCode 502 |
| 401 + empty body | `UNAUTHORIZED` |
| 200 + `installed:false` | `INSTANCE_NOT_CONFIGURED` |
| 200 + `installed:true` | `OK_SSL`, base url preserved |

`assembleOriginalDebug` builds and the app, domain, data and library unit test suites pass.