### PR TITLE
Fix androidTest junit classpath

### DIFF
--- a/.woodpecker/integration-test.yml
+++ b/.woodpecker/integration-test.yml
@@ -11,15 +11,15 @@ labels:
   platform: android-emulator
 
 steps:
-  - name: run tests
+  - name: integration tests
     image: *android_image
     commands:
       - adb connect android-emulator-cuda:5555
       - adb devices
-      - curl -L -o adbserver-desktop.jar https://github.com/KasperskyLab/Kaspresso/refs/tags/1.6.0/artifacts/adbserver-desktop.jar
+      - curl -fL -o adbserver-desktop.jar https://raw.githubusercontent.com/KasperskyLab/Kaspresso/v.1.6.0/artifacts/adbserver-desktop.jar
       - java -jar adbserver-desktop.jar &
       - sleep 3
-      - ./gradlew :opencloudApp:connectedOriginalDebugAndroidTest --console=plain
+      - ./gradlew :opencloudApp:connectedOriginalDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=eu.opencloud.android.IntegrationTest --console=plain
 
   - name: instrumented data tests
     image: *android_image

--- a/opencloudApp/build.gradle
+++ b/opencloudApp/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 
     // Instrumented tests
     androidTestImplementation project(":opencloudTestUtil")
+    androidTestImplementation libs.junit4
     androidTestImplementation libs.androidx.annotation
     androidTestImplementation libs.androidx.arch.core.testing
     androidTestImplementation libs.androidx.test.core

--- a/opencloudApp/src/integrationTest/docker-compose.yaml
+++ b/opencloudApp/src/integrationTest/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     hostname: android-emulator-cuda
     restart: unless-stopped
     environment:
-      - DISABLE_ANIMATION=false
+      - DISABLE_ANIMATION=true
       - DISABLE_HIDDEN_POLICY=true
       - SKIP_AUTH=false
       - MEMORY=16384

--- a/opencloudApp/src/integrationTest/java/eu/opencloud/android/IntegrationTest.kt
+++ b/opencloudApp/src/integrationTest/java/eu/opencloud/android/IntegrationTest.kt
@@ -1,0 +1,15 @@
+package eu.opencloud.android
+
+/**
+ * Marks an end-to-end integration test (src/integrationTest) that drives the real UI against a
+ * running OpenCloud server on the emulator, as opposed to the isolated instrumented tests.
+ *
+ * Run only these tests with:
+ *   ./gradlew :opencloudApp:connectedOriginalDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.annotation=eu.opencloud.android.IntegrationTest
+ *
+ * Retention must be RUNTIME so the AndroidJUnitRunner can read it for filtering.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class IntegrationTest

--- a/opencloudApp/src/integrationTest/java/eu/opencloud/android/LoginTest.kt
+++ b/opencloudApp/src/integrationTest/java/eu/opencloud/android/LoginTest.kt
@@ -13,6 +13,7 @@ import screens.MainScreen
 import screens.ManageAccountsDialog
 import screens.StartScreen
 
+@IntegrationTest
 class LoginTest : TestCase(
     kaspressoBuilder = Kaspresso.Builder.advanced {
         flakySafetyParams = FlakySafetyParams.custom(

--- a/opencloudComLibrary/build.gradle
+++ b/opencloudComLibrary/build.gradle
@@ -6,7 +6,12 @@ apply plugin: 'kotlin-parcelize'
 dependencies {
     api 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation libs.kotlin.stdlib
-    api 'com.github.opencloud-eu:android-dav:oc_support_2.1.6'
+    api('com.github.opencloud-eu:android-dav:oc_support_2.1.6') {
+        // xpp3:1.1.6 drags in a stray junit:junit:4.7 at runtime scope, which leaks
+        // into the production classpath and pins the androidTest classpath to
+        // "strictly 4.7" via AGP consistent resolution, breaking androidx.test (junit 4.13.2).
+        exclude group: 'junit', module: 'junit'
+    }
 
     // Androidx
     implementation libs.androidx.core.ktx


### PR DESCRIPTION
https://ci.opencloud.rocks/repos/30/pipeline/41/3
compileOriginalDebugAndroidTestKotlin failed with "Cannot access 'org.junit.rules.TestRule' which is a supertype of GrantPermissionRule" because junit4 was not on the androidTest compile classpath, and AGP  consistent resolution pinned the androidTest classpath to "strictly 4.7" 