### PR TITLE
Add "Take a photo" option to the "+" FAB menu

### DIFF
--- a/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
+++ b/opencloudApp/src/main/java/eu/opencloud/android/presentation/files/filelist/MainFileListFragment.kt
@@ -1013,16 +1013,19 @@ class MainFileListFragment : Fragment(),
             toggleFabVisibility(true)
             if (!currentFolder.hasAddFilePermission) {
                 binding.fabUpload.isVisible = false
+                binding.fabTakePhoto.isVisible = false
                 binding.fabNewfile.isVisible = false
             } else if (!currentFolder.hasAddSubdirectoriesPermission) {
                 binding.fabMkdir.isVisible = false
             }
             registerFabMainListener()
             registerFabUploadListener()
+            registerFabTakePhotoListener()
             registerFabMkDirListener()
             registerFabNewShortcutListener()
             binding.apply {
                 fabUpload.isFocusable = false
+                fabTakePhoto.isFocusable = false
                 fabMkdir.isFocusable = false
                 fabNewfile.isFocusable = false
                 fabNewshortcut.isFocusable = false
@@ -1041,6 +1044,7 @@ class MainFileListFragment : Fragment(),
     private fun toggleFabVisibility(shouldBeShown: Boolean) {
         binding.fabMain.isVisible = shouldBeShown
         binding.fabUpload.isVisible = shouldBeShown
+        binding.fabTakePhoto.isVisible = shouldBeShown
         binding.fabMkdir.isVisible = shouldBeShown
     }
 
@@ -1049,6 +1053,7 @@ class MainFileListFragment : Fragment(),
             fabMain.findViewById<View>(R.id.fab_expand_menu_button).setOnClickListener {
                 fabMain.toggle()
                 fabUpload.isFocusable = isFabExpanded()
+                fabTakePhoto.isFocusable = isFabExpanded()
                 fabMkdir.isFocusable = isFabExpanded()
                 fabNewfile.isFocusable = isFabExpanded()
                 fabNewshortcut.isFocusable = isFabExpanded()
@@ -1068,6 +1073,16 @@ class MainFileListFragment : Fragment(),
     private fun registerFabUploadListener() {
         binding.fabUpload.setOnClickListener {
             openBottomSheetToUploadFiles()
+            collapseFab()
+        }
+    }
+
+    /**
+     * Registers [android.view.View.OnClickListener] on the 'Take a photo' mini FAB for the linked action.
+     */
+    private fun registerFabTakePhotoListener() {
+        binding.fabTakePhoto.setOnClickListener {
+            uploadActions?.uploadFromCamera()
             collapseFab()
         }
     }
@@ -1108,6 +1123,7 @@ class MainFileListFragment : Fragment(),
         binding.apply {
             fabMain.collapse()
             fabUpload.isFocusable = false
+            fabTakePhoto.isFocusable = false
             fabMkdir.isFocusable = false
             fabNewfile.isFocusable = false
             fabNewshortcut.isFocusable = false

--- a/opencloudApp/src/main/res/drawable/ic_action_take_photo.xml
+++ b/opencloudApp/src/main/res/drawable/ic_action_take_photo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,15.2c1.8,0 3.2,-1.4 3.2,-3.2s-1.4,-3.2 -3.2,-3.2 -3.2,1.4 -3.2,3.2 1.4,3.2 3.2,3.2zM9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/opencloudApp/src/main/res/layout/main_file_list_fragment.xml
+++ b/opencloudApp/src/main/res/layout/main_file_list_fragment.xml
@@ -153,6 +153,17 @@
             fab:fab_title="@string/actionbar_upload" />
 
         <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_take_photo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/fab_take_photo"
+            fab:fab_colorNormal="@color/primary_button_background_color"
+            fab:fab_colorPressed="@color/opencloud_petrol"
+            fab:fab_icon="@drawable/ic_action_take_photo"
+            fab:fab_size="mini"
+            fab:fab_title="@string/fab_take_photo" />
+
+        <com.getbase.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_mkdir"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/opencloudApp/src/main/res/values/strings.xml
+++ b/opencloudApp/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="actionbar_sort_title">Sort by</string>
     <string name="fab_new_file">New document</string>
     <string name="fab_new_shortcut">New shortcut</string>
+    <string name="fab_take_photo">Take a photo</string>
     <string name="drawer_item_all_files">All files</string>
     <string name="drawer_item_only_available_offline">Available offline</string>
     <string name="drawer_item_shared_by_link_files">Shared by link</string>


### PR DESCRIPTION
Adds a dedicated **"Take a photo"** mini FAB to the "+" button menu, so users can
launch the camera and upload the capture directly — without going through
Upload → Picture from camera.

The existing camera option in the Upload bottom sheet remains unchanged.

## Changes
- `main_file_list_fragment.xml`: new `fab_take_photo` mini FAB with label,
  content description, and a new camera icon (`ic_action_take_photo`)
- `MainFileListFragment.kt`:
  - `registerFabTakePhotoListener()` reuses the existing
    `uploadActions?.uploadFromCamera()` flow (`FilesUploadHelper`)
  - Wired into FAB expand/collapse focus handling and `collapseFab()`
  - Hidden together with Upload/New document when the current folder has no
    add-file permission; shown/hidden with the rest of the FAB group

## Behavior
- Tap "+" → "Take a photo" → system camera opens → captured photo is uploaded
  to the current folder (same path as Upload → Picture from camera)
- No new permissions; still delegates to the system camera app via
  `ACTION_IMAGE_CAPTURE`
